### PR TITLE
Updated FAQ dropdown questions and answers

### DIFF
--- a/apps/main/src/app/(landing)/Sections/FAQ.tsx
+++ b/apps/main/src/app/(landing)/Sections/FAQ.tsx
@@ -13,7 +13,7 @@ export default function FAQSection(): React.ReactNode {
           FAQs
         </h1>
 
-        <div className="w-3/5 mx-auto flex">
+        <div className="w-3/5 mx-auto flex z-10">
           <h3 className="text-2xl font-semibold text-white">
             Time and Location
           </h3>
@@ -21,26 +21,26 @@ export default function FAQSection(): React.ReactNode {
 
         <div className="flex justify-center w-3/5 self-center">
           <FAQDropdown
-            dropdownQuestion="When and where is HackBeanpot 2025?"
-            dropdownAnswer="Location TBD!"
+            dropdownQuestion="When and where is HackBeanpot 2026?"
+            dropdownAnswer="HackBeanpot will take place in the spring semester of 2026. Location TBD!"
           />
         </div>
 
         <div className="flex justify-center w-3/5 self-center">
           <FAQDropdown
-            dropdownQuestion="Will HackBeanpot 2025 be in-person or online?"
-            dropdownAnswer="In person!"
+            dropdownQuestion="Will HackBeanpot 2026 be in-person or online?"
+            dropdownAnswer="HackBeanpot 2026 will be in-person!"
           />
         </div>
         <div className="flex justify-center w-3/5 self-center">
           <FAQDropdown
             dropdownQuestion="How long is the event?"
-            dropdownAnswer="long time."
+            dropdownAnswer="Our Hackathon is typically 36 hours long!"
           />
         </div>
 
         <div className="w-3/5 mx-auto flex">
-          <h3 className="text-2xl font-semibold text-white pt-10">
+          <h3 className="text-2xl font-semibold text-white pt-10 z-10">
             Application Logistics
           </h3>
         </div>
@@ -48,12 +48,12 @@ export default function FAQSection(): React.ReactNode {
         <div className="flex justify-center w-3/5 self-center">
           <FAQDropdown
             dropdownQuestion="How do I apply to attend HackBeanpot?"
-            dropdownAnswer="Fill out the application here!"
+            dropdownAnswer="Our applications have not been released yet for the 2026 Hackathon! Be sure to connect with us on our social media or join our mailing list for any updates!"
           />
         </div>
 
         <div className="w-3/5 mx-auto flex">
-          <h3 className="text-2xl font-semibold text-white pt-10">
+          <h3 className="text-2xl font-semibold text-white pt-10 z-10">
             Event Logistics
           </h3>
         </div>
@@ -61,7 +61,14 @@ export default function FAQSection(): React.ReactNode {
         <div className="flex justify-center w-3/5 self-center">
           <FAQDropdown
             dropdownQuestion="What kind of projects can I work on?"
-            dropdownAnswer="..."
+            dropdownAnswer={
+              <>
+                Check out our <a href="https://www.hackbeanpot.com/projects" className="text-blue-500 underline" 
+                target="_blank" rel="noopener noreferrer">Projects</a> page or check us out on <a 
+                href="https://hackbeanpot2025.devpost.com/" className="text-blue-500 underline" 
+                target="_blank" rel="noopener noreferrer">Devpost</a>!
+              </>
+            }
           />
         </div>
 


### PR DESCRIPTION
# <Summary line - I changed the answers to the frequently asked questions to reflect the current information for the 2026 Hackathon.

## 🎫 Issue #<bug number>.
85


### ▶ Changelist:

- Changed the answers to the frequently asked questions
- For one of the answers, added links to the HackBeanpot projects page and the Devpost page.
- Fixed bug with displaying smaller titles in FAQ section that were not showing up previously

### 🧪 Testing:

- Manual and visual testing while running website locally and clicking on dropdown and seeing updated information

### 🎥 Screenshots & Screencasts:
<img width="1792" alt="Screenshot 2025-05-23 at 7 29 16 PM" src="https://github.com/user-attachments/assets/837956f5-5a97-4c72-98e3-e40c93818aee" />
<img width="1789" alt="Screenshot 2025-05-23 at 7 29 24 PM" src="https://github.com/user-attachments/assets/0883ea1c-b511-4123-bbaa-a74bee203e06" />
