### PR TITLE
SK/our-team-section

### DIFF
--- a/apps/main/src/app/team/OurTeamDropdown.tsx
+++ b/apps/main/src/app/team/OurTeamDropdown.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React, { useState, useRef, useEffect } from 'react';
+
+const teams = [
+  'Directors',
+  'Tech',
+  'Design',
+  'Social',
+  'Sponsorship',
+  'Operations'
+] as const;
+
+type TeamName = typeof teams[number];
+
+interface OurTeamDropdownProps {
+  onTeamSelect: (team: TeamName) => void;
+  selectedTeam?: TeamName;
+}
+
+function OurTeamDropdown({ onTeamSelect, selectedTeam = 'Directors' }: OurTeamDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleTeamSelect = (team: TeamName) => {
+    onTeamSelect(team);
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative inline-block text-left mb-8" ref={dropdownRef}>
+      <div>
+        <button 
+          type="button" 
+          className="inline-flex items-center justify-center gap-x-2 bg-transparent px-0 py-2 text-lg font-medium text-gray-800 hover:text-gray-600 transition-colors duration-200" 
+          onClick={toggleDropdown}
+          aria-expanded={isOpen}
+          aria-haspopup="true"
+        >
+          {selectedTeam}
+          <svg 
+            className={`w-4 h-4 text-gray-600 transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`} 
+            viewBox="0 0 20 20" 
+            fill="currentColor" 
+            aria-hidden="true"
+          >
+            <path fillRule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clipRule="evenodd" />
+          </svg>
+        </button>
+      </div>
+      
+      {isOpen && (
+        <div className="absolute left-1/2 transform -translate-x-1/2 z-50 mt-2 w-48 origin-top rounded-md bg-white shadow-lg ring-1 ring-black/5 border border-gray-200">
+          <div className="py-1">
+            {teams.map((team: TeamName) => (
+              <button
+                key={team}
+                onClick={() => handleTeamSelect(team)}
+                className={`block w-full text-left px-4 py-2 text-sm transition-colors duration-150 ${
+                  selectedTeam === team 
+                    ? 'bg-blue-50 text-blue-700 font-medium' 
+                    : 'text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {team}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default OurTeamDropdown;

--- a/apps/main/src/app/team/Sections/Landing.tsx
+++ b/apps/main/src/app/team/Sections/Landing.tsx
@@ -17,12 +17,12 @@ const Landing = () => {
         alt=""
         fill
         priority
-        className="object-cover z-0"
+        className="tablet:object-cover object-contain"
         sizes="100vw"
-        style={{ objectFit: "cover" }}
+        style={{ objectPosition: "center 0%" }}
       />
-      <div className="absolute inset-0 flex items-center justify-center z-10">
-        <span className="font-Wilden text-[10rem] text-text-light [text-shadow:_0_10px_0_rgb(0_0_0_/_20%)]">
+      <div className="absolute inset-0 flex items-center justify-center z-10 px-4 top-[-75%] tablet:top-0">
+        <span className="font-Wilden text-[3rem] tablet:text-[10rem] text-text-light text-center [text-shadow:_0_10px_0_rgb(0_0_0_/_20%)] leading-tight">
           Our Team
         </span>
       </div>

--- a/apps/main/src/app/team/Sections/Teams.tsx
+++ b/apps/main/src/app/team/Sections/Teams.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import Image from "next/image";
 import LinkedInLogo from "@repo/ui/LinkedInLogo";
 import useWindowSize from "@repo/util/hooks/useWindowSize";
+import OurTeamDropdown from "../OurTeamDropdown";
+
 import {
   TeamsBottomSquiggle,
   TeamsMiddleSquiggle,
@@ -21,11 +23,11 @@ type TeamSectionsProps = {
 
 const TeamSections = ({ team }: TeamSectionsProps) => {
   return (
-    <div>
-      <h2 className="text-4xl text-black font-semibold font-GT-Walsheim-Regular">
+    <div className="mb-12 tablet:px-20">
+      <h2 className="text-2xl tablet:text-4xl text-black font-semibold font-GT-Walsheim-Regular mb-6 tablet:mb-4">
         {team}
       </h2>
-      <div className="grid grid-cols-[repeat(auto-fill,_minmax(200px,_1fr))] gap-3  py-5">
+      <div className="grid grid-cols-2 tablet:grid-cols-5 gap-3 sm:gap-4 lg:gap-6 tablet:gap-8 justify-items-center">
         {teams[team].map((member) => (
           <Headshot key={member.name} name={member.name} src={member.src} />
         ))}
@@ -36,21 +38,22 @@ const TeamSections = ({ team }: TeamSectionsProps) => {
 
 const Headshot = ({ name, src }: HeadshotProps) => {
   return (
-    <div className="flex flex-col w-fit">
+    <div className="flex flex-col w-full max-w-[140px] tablet:max-w-[250px]">
       <Image
         alt={name}
         src={src}
         width={400}
         height={400}
-        className="rounded"
+        className="rounded w-full h-auto aspect-square object-cover"
       />
-      <div className="flex items-center font-semibold">
+      <div className="flex items-center font-semibold mt-3 text-sm tablet:text-lg">
         <LinkedInLogo />
-        {name}
+        <span className="ml-2">{name}</span>
       </div>
     </div>
   );
 };
+
 const teams = {
   Directors: [
     { name: "Mike Mundia", src: "/headshots/directors/mike.png" },
@@ -86,7 +89,7 @@ const teams = {
     { name: "Nidhi Pillai", src: "/headshots/sponsorship/nidhi.png" },
     { name: "Sammi Chen", src: "/headshots/sponsorship/sammi.png" },
     { name: "Harini Avula", src: "/headshots/sponsorship/harini.png" },
-    { name: "Swar Kewaiia", src: "/headshots/sponsorship/swar.png" },
+    { name: "Swar Kewalia", src: "/headshots/sponsorship/swar.png" },
     { name: "Tiffany Zheng", src: "/headshots/sponsorship/tiffany.png" },
   ],
   Operations: [
@@ -103,18 +106,49 @@ const teams = {
 const Teams = () => {
   const ref = useRef<HTMLDivElement>(null);
   const { height: windowHeight, width: windowWidth } = useWindowSize();
+  const [selectedTeam, setSelectedTeam] = useState<keyof typeof teams>("Directors");
 
-  if (!windowHeight || !windowWidth) return;
+  if (!windowHeight || !windowWidth) return null;
+
+  const handleTeamSelect = (team: keyof typeof teams) => {
+    setSelectedTeam(team);
+  };
+
+  const getTeamsToDisplay = () => {
+    return [[selectedTeam, teams[selectedTeam]]] as [keyof typeof teams, typeof teams[keyof typeof teams]][];
+  };
+
+  const getAllTeams = () => {
+    return Object.entries(teams) as [keyof typeof teams, typeof teams[keyof typeof teams]][];
+  };
 
   const TeamsContent = () => {
     return (
-      <div ref={ref} className="p-[8vw]">
-        {Object.entries(teams).map(([teamName, team]) => (
-          <TeamSections
-            key={team.toString()}
-            team={teamName as keyof typeof teams}
+      <div ref={ref} className="p-4 sm:p-[6vw] lg:p-[8vw]">
+        <div className="text-center mb-6 sm:mb-8 tablet:-mt-[10vh] -mt-[75vh] tablet:hidden">
+          <OurTeamDropdown 
+            onTeamSelect={handleTeamSelect}
+            selectedTeam={selectedTeam}
           />
-        ))}
+        </div>
+        
+        <div className="tablet:hidden">
+          {getTeamsToDisplay().map(([teamName, team]) => (
+            <TeamSections
+              key={teamName}
+              team={teamName}
+            />
+          ))}
+        </div>
+
+        <div className="hidden tablet:block">
+          {getAllTeams().map(([teamName, team]) => (
+            <TeamSections
+              key={teamName}
+              team={teamName}
+            />
+          ))}
+        </div>
       </div>
     );
   };
@@ -122,7 +156,7 @@ const Teams = () => {
   return (
     <div className="relative w-full min-h-screen">
       <div className="absolute inset-0 w-full h-full pointer-events-none z-0">
-        <TeamsTopSquiggle className="w-[110vw] -mt-48 -ml-[5vw]" />
+        <TeamsTopSquiggle className="w-[110vw] -mt-[130vh] tablet:-mt-48 -ml-[5vw]" />
         <TeamsMiddleSquiggle className="w-[110vw] -ml-[10vw]" />
         <TeamsBottomSquiggle className="w-[110vw] -ml-[5vw]" />
       </div>


### PR DESCRIPTION
Reformated 'Our Team' page for mobile screens, and implemented a dropdown feature for mobile that lets the user switch between teams. 

## 🎫 Issue #115 

## 🎨 Figma Link: https://www.figma.com/design/xkYK4nbALjkUNW5Ikl8FYH/Roadtrip-Website-Wireframes?node-id=1-2&p=f&t=8hcGjWmbW3fATm93-0

### ▶ Changelist:

-  Reformated title image to fit mobile screen
- Reformated team layout, pictures and text to fit mobile screen
- Implemented dropdown feature so user can switch between teams

### 📝 Notes + 🚧 TODO: 

- This does **not** include the header or footer!!!!!!

### 🧪 Testing:

- Tested for mobile on 390 x 684

### 🎥 Screenshots & Screencasts:

- Include screenshots and screencasts as relevant
- Be liberal and provide all the user / developer flow context that you can
- Remember to make changes and re-render when you put out any PR revision
<img width="366" alt="Screenshot 2025-06-13 at 7 46 48 PM" src="https://github.com/user-attachments/assets/ed5b46f9-7767-416d-8d5b-56b12e3bbea0" />
