### PR TITLE
KK/keynote-mobile-screen

### DIFF
--- a/apps/main/src/app/(landing)/Sections/Apply.tsx
+++ b/apps/main/src/app/(landing)/Sections/Apply.tsx
@@ -10,9 +10,9 @@ import ApplyRightBush from "../../lib/Assets/SVG/ApplyAssets/ApplyRightBush";
 const Apply = () => {
   return (
     <>
-      <div className="relative w-full mt-44 flex flex-col flex-none h-[559px]">
+      <div className="relative w-full mt-44 flex flex-col flex-none h-[68vh]">
         <div className="w-full h-full z-0">
-          <ApplyBackground height={555} preserveAspectRatio="none"/>
+          <ApplyBackground preserveAspectRatio="xMidYMid meet"/>
         </div>
 
         <div className="relative top-[-480px] z-10 flex justify-center items-center w-full h-full">

--- a/apps/main/src/app/(landing)/Sections/Keynote.tsx
+++ b/apps/main/src/app/(landing)/Sections/Keynote.tsx
@@ -3,28 +3,50 @@
 import React from "react";
 import StreetSign from "@repo/ui/StreetSign";
 import Image from "next/image";
-import useIsMobile from "@repo/util/hooks/useIsMobile";
+import useIsLargeMobile from "@repo/util/hooks/useIsMobileLgScreen";
 import Typography from "@repo/ui/Typography";
 
-function SpeakerPhoto(): JSX.Element {
+interface AdditionalClassesProps {
+  additionalClasses?: string;
+};
+
+interface SpeakerPhotoProps {
+  newWidth?: number;
+  newHeight?: number;
+  newPadding?: string;
+  newMinWidth?: string;
+  newClasses?: string;
+};
+
+interface SpeakerDetailsProps {
+  textAlign?: string;
+  scaleFactor?: string;
+}
+
+function SpeakerPhoto({ newWidth, newHeight, newPadding, newMinWidth, newClasses }: SpeakerPhotoProps): JSX.Element {
+  const padding = newPadding ?? "p-4";
+  const width = newWidth ?? 400;
+  const height = newHeight ?? 500;
+  const minWidth = newMinWidth ?? "min-w-200px";
+
   return (
-    <div className="bg-white rounded-md inline-block p-4 pb-[5vw] shadow-lg">
+    <div className={`bg-white rounded-sm inline-block pb-[5vw] shadow-lg ${padding} ${newClasses ?? ''}`}>
       <Image
         alt="Aidan"
         src="/aidan.png"
-        width={400}
-        height={500}
-        className="min-w-[200px]"
+        width={width}
+        height={height}
+        className={minWidth}
       />
     </div>
   );
 }
 
-function SpeakerDetails(): JSX.Element {
+function SpeakerDetails({ textAlign, scaleFactor }: SpeakerDetailsProps): JSX.Element {
   return (
-    <div className="mt-4 font-GT-Walsheim-Regular">
-      <p className="text-[1.75vw] font-bold mb-2">Aidan Ouckama</p>
-      <p className="text-[1.5vw] text-lightBrown">
+    <div className={`mt-[15%] font-GT-Walsheim-Regular ${textAlign ?? ''}`}>
+      <p className={`text-[1.75vw] scale-[${scaleFactor ?? "1"}] font-bold mb-[30%]`}>Aidan Ouckama</p>
+      <p className={`text-[1.5vw] scale-[${scaleFactor ?? "1"}] text-lightBrown`}>
         3rd year Computer Science student, Stevens Institute of Technology |
         Tech Content Creator
       </p>
@@ -32,9 +54,9 @@ function SpeakerDetails(): JSX.Element {
   );
 }
 
-function SpeakerAbout(): JSX.Element {
+function SpeakerAbout({ additionalClasses }: AdditionalClassesProps): JSX.Element {
   return (
-    <Typography.Body className="font-GT-Walsheim-Regular mt-8">
+    <Typography.Body className={`font-GT-Walsheim-Regular mt-8 ${additionalClasses ?? ''}`}>
       <span className="font-GT-Walsheim-Bold">Aidan Ouckama </span>is a a
       prominent tech content creator, known for engaging, informative, and
       humorous content across multiple social media platforms. By sharing
@@ -58,25 +80,34 @@ function SpeakerAbout(): JSX.Element {
 }
 
 export default function Keynote(): React.ReactNode {
-  const isMobile = useIsMobile();
+  const isMobile = useIsLargeMobile();
+
+  const conditionalAlignment = (`h-full mx-auto my-auto gap-5 ${
+    isMobile
+      ? "flex flex-col items-center justify-center min-h-screen text-center"
+      : "flex items-center"
+  }`);
+
   return (
-    <div className="w-full h-[120vh] bg-cream">
+    <div className={`w-full bg-cream ${isMobile ? "h-auto" : "h-[120vh]"}`}>
       <div
-        className={`h-full max-w-[80vw] mx-auto my-auto gap-5 ${
-          isMobile
-            ? "flex flex-col items-center justify-center min-h-screen text-center"
-            : "flex items-center"
-        }`}
+        className={conditionalAlignment}
       >
-        <div className="w-[45vw]">
-          {isMobile && <StreetSign streetName="KEYNOTE" suffix="SPEAKER" />}
-          <SpeakerPhoto />
-          <SpeakerDetails />
+        <div className={`${isMobile ? "w-[80vw]" : "w-[55vw]"}`}>
+          {isMobile && 
+          <div className={`relative ${isMobile ? "mb-[5%] mt-10 justify-self-center scale-[0.7]": "mb-[10%]"}`}>
+            <StreetSign streetName="KEYNOTE" suffix="SPEAKER" />
+          </div>}
+          
+          <div className={`${isMobile ? "flex flex-row gap-x-12 mb-[-5%]" : ""}`}>
+            <SpeakerPhoto newClasses={`${isMobile ? "left-[-10%]" : ""}`} newPadding={`${isMobile ? "p-2" : ""}`}/>
+            <SpeakerDetails textAlign={`${isMobile ? "text-left text-wrap p-[5%]" : ""}`} scaleFactor={`${isMobile ? "2" : ""}`}/>
+          </div>
         </div>
 
-        <div className="w-[55vw]">
+        <div className={`${isMobile ? "w-[80vw]" : "w-[55vw]"}`}>
           {!isMobile && <StreetSign streetName="KEYNOTE" suffix="SPEAKER" />}
-          <SpeakerAbout />
+          <SpeakerAbout additionalClasses={`${isMobile ? "text-left" : ""}`} />
         </div>
       </div>
     </div>

--- a/packages/util/src/hooks/useIsMobileLgScreen.ts
+++ b/packages/util/src/hooks/useIsMobileLgScreen.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+
+const useIsMobileLgScreen = () => {
+    const [isMobile, setIsMobile] = useState(false);
+
+    useEffect(() => {
+        const checkMobile = () => {
+            setIsMobile(window.innerWidth < 450);
+        };
+
+        checkMobile();
+        window.addEventListener("resize", checkMobile);
+        return () => window.removeEventListener("resize", checkMobile);
+    }, []);
+
+    return isMobile;
+};
+
+export default useIsMobileLgScreen;


### PR DESCRIPTION
# Updated keynote speaker mobile responsiveness

## 🎫 Issue #113 

## 🎨 [Figma Link](https://www.figma.com/design/xkYK4nbALjkUNW5Ikl8FYH/Roadtrip-Website-Wireframes?node-id=398-134)

### ▶ Changelist:
- Added a new hook to accommodate for larger mobile screen sizes
- Updated how the keynote speaker section looked when on mobile

### 📝 Notes + 🚧 TODO:
- Decided to add a new hook because the previous hook was only accommodating mobile screens of max 300px size. Most phones are upwards of 415px wide now
- **Potential follow-up**: consider adjusting our mobile screen to in screens.ts to be a bit larger
- Long term refactoring plans: would like to look into why the keynote speaker code defaults to desktop styles on devtools
Example: 
![image (6)](https://github.com/user-attachments/assets/81625798-f9f0-473a-8582-f1455e27178f)

### 🧪 Testing:

- Tested using phones offered in devtools
- Tested on my own phone (430 x 932 pixels)

### 🎥 Screenshots & Screencasts:
![IMG_4172](https://github.com/user-attachments/assets/b7d4622c-884d-4ee6-83bb-e50bb37b0e70)

https://github.com/user-attachments/assets/f50f59ca-ff13-4b2d-b8a5-b27b9b7e5425



