### PR TITLE
fixed Testimonials mobile screen & card refactor #111

### DIFF
--- a/apps/main/next-env.d.ts
+++ b/apps/main/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/apps/main/pages/_document.tsx
+++ b/apps/main/pages/_document.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import Document, { Html, Head, Main, NextScript } from "next/document";
 
 export default class MyDocument extends Document {

--- a/apps/main/pages/_document.tsx
+++ b/apps/main/pages/_document.tsx
@@ -1,0 +1,15 @@
+import Document, { Html, Head, Main, NextScript } from "next/document";
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}

--- a/apps/main/tsconfig.json
+++ b/apps/main/tsconfig.json
@@ -1,11 +1,25 @@
 {
   "extends": "@repo/typescript-config/nextjs.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "paths": {
-      "@util/*": ["../../packages/util/src/*"]
-    }
+      "@util/*": [
+        "../../packages/util/src/*"
+      ]
+    },
+    "strictNullChecks": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/packages/ui/src/ArrowButton.tsx
+++ b/packages/ui/src/ArrowButton.tsx
@@ -44,6 +44,7 @@ export default function ArrowButton({
       <button
         onClick={onClick}
         className={clsx(
+          "hidden md:flex items-center justify-center",
           `rounded-arrow w-24 h-24 ${bgColor} ${topBorder} border-t-4 hover:scale-105 transition-transform`,
           className,
         )}

--- a/packages/ui/src/Carousel.tsx
+++ b/packages/ui/src/Carousel.tsx
@@ -1,28 +1,74 @@
 "use client";
-import React from "react";
+
+import React, { useState } from "react";
 import PassportCard, { PassportCardProps } from "./PassportCard";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface CarouselProps {
   items: PassportCardProps[];
 }
 
 const Carousel: React.FC<CarouselProps> = ({ items }) => {
-  return (
-    <div className="flex justify-center items-center space-x-80">
-      {items.map((cardInfo, i) => {
-        const isActive = i === 1;
-        const activeClass = isActive ? "opacity-100 z-10" : "opacity-70 z-0";
-        const updatedInfo = { ...cardInfo, isActive };
+  // ── active slide index ────────────────────────────────────────────
+  const [active, setActive] = useState(0);
 
-        return (
-          <div
-            key={cardInfo.id}
-            className={`transition-opacity duration-300 ${activeClass}`}
-          >
-            <PassportCard {...updatedInfo} />
-          </div>
-        );
-      })}
+  const prev = () => setActive((i) => (i === 0 ? items.length - 1 : i - 1));
+  const next = () => setActive((i) => (i === items.length - 1 ? 0 : i + 1));
+  const goTo = (i: number) => setActive(i);
+
+  // ── layout ────────────────────────────────────────────────────────
+  return (
+    <div className="relative w-full flex items-center justify-center">
+      {/* ── CARD STACK ─────────────────────────────────────────────── */}
+      <div className="flex justify-center items-center space-x-80">
+        {items.map((cardInfo, i) => {
+          const isActive = i === active;
+          const activeClass = isActive ? "opacity-100 z-10" : "opacity-70 z-0";
+          return (
+            <div
+              key={cardInfo.id}
+              className={`transition-opacity duration-300 ${activeClass}`}
+            >
+              <PassportCard {...cardInfo} isActive={isActive} />
+            </div>
+          );
+        })}
+      </div>
+
+      {/* ── LEFT ARROW (desktop / tablet only) ────────────────────── */}
+      <button
+        aria-label="Previous testimonial"
+        onClick={prev}
+        className="hidden sm:flex items-center justify-center
+                   absolute left-4 top-1/2 -translate-y-1/2
+                   w-12 h-12 rounded-xl bg-[#008773] shadow-lg z-20"
+      >
+        <ChevronLeft size={28} className="text-white" />
+      </button>
+
+      {/* ── RIGHT ARROW (desktop / tablet only) ───────────────────── */}
+      <button
+        aria-label="Next testimonial"
+        onClick={next}
+        className="hidden sm:flex items-center justify-center
+                   absolute right-4 top-1/2 -translate-y-1/2
+                   w-12 h-12 rounded-xl bg-[#008773] shadow-lg z-20"
+      >
+        <ChevronRight size={28} className="text-white" />
+      </button>
+
+      {/* ── PAGINATION DOTS (always visible) ─────────────────────── */}
+      <div className="flex justify-center gap-2 absolute bottom-6">
+        {items.map((_, i) => (
+          <button
+            key={i}
+            aria-label={`Show testimonial ${i + 1}`}
+            onClick={() => goTo(i)}
+            className={`h-3 w-3 rounded-full transition-colors
+                        ${i === active ? "bg-[#008773]" : "bg-[#C4C4C4]"}`}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/packages/ui/src/Carousel.tsx
+++ b/packages/ui/src/Carousel.tsx
@@ -1,8 +1,9 @@
+/* components/Carousel.tsx */
 "use client";
 
 import React, { useState } from "react";
 import PassportCard, { PassportCardProps } from "./PassportCard";
-import ArrowButton from "./ArrowButton";
+
 interface CarouselProps {
   items: PassportCardProps[];
 }
@@ -11,58 +12,66 @@ const Carousel: React.FC<CarouselProps> = ({ items }) => {
   const [active, setActive] = useState(0);
   const len = items.length;
 
-  /* helpers */
-  const idxPrev = (i: number) => (i === 0 ? len - 1 : i - 1);
-  const idxNext = (i: number) => (i === len - 1 ? 0 : i + 1);
+  /* ── helpers ────────────────────────────────────────── */
+  const prevIndex = (i: number) => (i === 0 ? len - 1 : i - 1);
+  const nextIndex = (i: number) => (i === len - 1 ? 0 : i + 1);
 
-  const goPrev = () => setActive(idxPrev);
-  const goNext = () => setActive(idxNext);
-  const goTo = (i: number) => setActive(i);
+  const goPrev = () => setActive(prevIndex);
+  const goNext = () => setActive(nextIndex);
 
-  /* order: prev | active | next  so active stays centre */
-  const renderOrder = [idxPrev(active), active, idxNext(active)];
+  /* build array [prev, active, next] so active is center  */
+  const visibleIdx = [prevIndex(active), active, nextIndex(active)];
 
   return (
     <div className="relative w-full flex items-center justify-center">
-      {/* CARD STRIP */}
+      {/* ── CARD STRIP (prev | active | next) ──────────── */}
       <div className="flex justify-center items-center space-x-80">
-        {renderOrder.map((idx) => {
-          const c = items[idx];
+        {visibleIdx.map((idx, pos) => {
+          const card = items[idx];
           const isActive = idx === active;
           const opacity = isActive ? "opacity-100 z-10" : "opacity-70 z-0";
+
           return (
             <div
-              key={c.id}
+              key={card.id}
               className={`transition-opacity duration-300 ${opacity}`}
             >
-              <PassportCard {...c} isActive={isActive} />
+              <PassportCard {...card} isActive={isActive} />
             </div>
           );
         })}
       </div>
 
-      {/* ARROWS */}
-      <ArrowButton
-        direction="left"
-        arrowButtonColor="greenButton"
+      {/* ── ARROW BUTTONS ── hidden on < 768 px ───────── */}
+      <button
+        aria-label="Previous testimonial"
         onClick={goPrev}
-        className="hidden md:flex absolute left-4 top-1/2 -translate-y-1/2 z-20"
-      />
+        className="hidden md:flex items-center justify-center
+                   absolute left-4 top-1/2 -translate-y-1/2
+                   w-12 h-12 rounded-xl bg-[#008773] shadow-lg
+                   text-white text-2xl z-20"
+      >
+        ←
+      </button>
 
-      <ArrowButton
-        direction="right"
-        arrowButtonColor="greenButton"
+      <button
+        aria-label="Next testimonial"
         onClick={goNext}
-        className="hidden md:flex absolute right-4 top-1/2 -translate-y-1/2 z-20"
-      />
+        className="hidden md:flex items-center justify-center
+                   absolute right-4 top-1/2 -translate-y-1/2
+                   w-12 h-12 rounded-xl bg-[#008773] shadow-lg
+                   text-white text-2xl z-20"
+      >
+        →
+      </button>
 
-      {/* DOTS  (always visible) */}
+      {/* ── PAGINATION DOTS (always visible) ──────────── */}
       <div className="flex justify-center gap-2 absolute bottom-6">
         {items.map((_, i) => (
           <button
             key={i}
+            onClick={() => setActive(i)}
             aria-label={`Show testimonial ${i + 1}`}
-            onClick={() => goTo(i)}
             className={`h-3 w-3 rounded-full transition-colors
                         ${i === active ? "bg-[#008773]" : "bg-[#C4C4C4]"}`}
           />

--- a/packages/ui/src/Carousel.tsx
+++ b/packages/ui/src/Carousel.tsx
@@ -2,62 +2,61 @@
 
 import React, { useState } from "react";
 import PassportCard, { PassportCardProps } from "./PassportCard";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-
+import ArrowButton from "./ArrowButton";
 interface CarouselProps {
   items: PassportCardProps[];
 }
 
 const Carousel: React.FC<CarouselProps> = ({ items }) => {
-  // ── active slide index ────────────────────────────────────────────
   const [active, setActive] = useState(0);
+  const len = items.length;
 
-  const prev = () => setActive((i) => (i === 0 ? items.length - 1 : i - 1));
-  const next = () => setActive((i) => (i === items.length - 1 ? 0 : i + 1));
+  /* helpers */
+  const idxPrev = (i: number) => (i === 0 ? len - 1 : i - 1);
+  const idxNext = (i: number) => (i === len - 1 ? 0 : i + 1);
+
+  const goPrev = () => setActive(idxPrev);
+  const goNext = () => setActive(idxNext);
   const goTo = (i: number) => setActive(i);
 
-  // ── layout ────────────────────────────────────────────────────────
+  /* order: prev | active | next  so active stays centre */
+  const renderOrder = [idxPrev(active), active, idxNext(active)];
+
   return (
     <div className="relative w-full flex items-center justify-center">
-      {/* ── CARD STACK ─────────────────────────────────────────────── */}
+      {/* CARD STRIP */}
       <div className="flex justify-center items-center space-x-80">
-        {items.map((cardInfo, i) => {
-          const isActive = i === active;
-          const activeClass = isActive ? "opacity-100 z-10" : "opacity-70 z-0";
+        {renderOrder.map((idx) => {
+          const c = items[idx];
+          const isActive = idx === active;
+          const opacity = isActive ? "opacity-100 z-10" : "opacity-70 z-0";
           return (
             <div
-              key={cardInfo.id}
-              className={`transition-opacity duration-300 ${activeClass}`}
+              key={c.id}
+              className={`transition-opacity duration-300 ${opacity}`}
             >
-              <PassportCard {...cardInfo} isActive={isActive} />
+              <PassportCard {...c} isActive={isActive} />
             </div>
           );
         })}
       </div>
 
-      {/* ── LEFT ARROW (desktop / tablet only) ────────────────────── */}
-      <button
-        aria-label="Previous testimonial"
-        onClick={prev}
-        className="hidden sm:flex items-center justify-center
-                   absolute left-4 top-1/2 -translate-y-1/2
-                   w-12 h-12 rounded-xl bg-[#008773] shadow-lg z-20"
-      >
-        <ChevronLeft size={28} className="text-white" />
-      </button>
+      {/* ARROWS */}
+      <ArrowButton
+        direction="left"
+        arrowButtonColor="greenButton"
+        onClick={goPrev}
+        className="hidden md:flex absolute left-4 top-1/2 -translate-y-1/2 z-20"
+      />
 
-      {/* ── RIGHT ARROW (desktop / tablet only) ───────────────────── */}
-      <button
-        aria-label="Next testimonial"
-        onClick={next}
-        className="hidden sm:flex items-center justify-center
-                   absolute right-4 top-1/2 -translate-y-1/2
-                   w-12 h-12 rounded-xl bg-[#008773] shadow-lg z-20"
-      >
-        <ChevronRight size={28} className="text-white" />
-      </button>
+      <ArrowButton
+        direction="right"
+        arrowButtonColor="greenButton"
+        onClick={goNext}
+        className="hidden md:flex absolute right-4 top-1/2 -translate-y-1/2 z-20"
+      />
 
-      {/* ── PAGINATION DOTS (always visible) ─────────────────────── */}
+      {/* DOTS  (always visible) */}
       <div className="flex justify-center gap-2 absolute bottom-6">
         {items.map((_, i) => (
           <button

--- a/packages/ui/src/PassportCard.tsx
+++ b/packages/ui/src/PassportCard.tsx
@@ -28,63 +28,62 @@ export default function PassportCard({
   isActive,
 }: PassportCardProps): React.ReactNode {
   const positionClass = isActive ? "top-[20%]" : "top-[22%]";
-
   const scaleClass = isActive ? "scale-100" : "scale-[75%]";
 
   return (
     <div className="flex justify-center items-center w-full font-GT-Walsheim-Pro-Regular font-bold">
       <div
-        className={`bg-white h-4/6 rounded-3xl w-1/3 ${scaleClass} absolute ${positionClass} shadow-[0_15px_0px_-5px_rgba(221,198,168,1)] grid grid-rows-[49.5%_1%_49.5%] space-x-2`}
+        className={`bg-white rounded-3xl shadow-[0_15px_0px_-5px_rgba(221,198,168,1)] ${scaleClass} absolute ${positionClass} transition-all w-[30%] sm:w-[60%] md:w-[45%] lg:w-[30%]`}
       >
-        <div className={`transition-all duration-300 relative`}>
-          <div className="flex flex-shrink items-center w-full ml-[5%]">
-            <div className="grid grid-rows-[30%_70%]">
-              <div className="flex items-center space-x-2 mb-[10%]">
+        {/* --- TOP SECTION --- */}
+        <div className="p-4 md:p-6 lg:p-8 border-b border-[#DDC6A8]">
+          <div className="flex items-start space-x-4">
+            {/* Left side: photo and passport header */}
+            <div className="flex-shrink-0">
+              <div className="flex items-center space-x-2 mb-4">
                 <Image
                   alt="passport icon"
                   src={"/passport_icon.svg"}
-                  width={50}
-                  height={100}
-                  className="rounded-md"
+                  width={32}
+                  height={32}
                 />
-                <h1 className="text-xl">PASSPORT</h1>
+                <h1 className="text-lg md:text-xl">PASSPORT</h1>
               </div>
               <Image
-                alt={firstName + lastName + id}
+                alt={`${firstName}${lastName}${id}`}
                 src={image}
-                width={120}
-                height={195}
-                className="max-w-full h-auto object-contain"
+                width={100}
+                height={100}
+                className="rounded-md object-cover"
               />
             </div>
-            <div className="flex flex-shrink mr-[5%] mt-[15%] w-3/5 justify-between">
-              <div className="flex flex-col">
-                <p className="text-xs text-[#B1B1B2] mt-[5%]">First name</p>
+
+            {/* Right side: personal info */}
+            <div className="flex-grow flex flex-col sm:flex-row sm:justify-between w-full space-y-2 sm:space-y-0 sm:space-x-6">
+              <div>
+                <p className="text-xs text-[#B1B1B2]">First name</p>
                 <h2>{firstName.toUpperCase()}</h2>
-                <p className="text-xs text-[#B1B1B2] mt-[5%]">Last name</p>
+                <p className="text-xs text-[#B1B1B2] mt-2">Last name</p>
                 <h2>{lastName.toUpperCase()}</h2>
-                <p className="text-xs text-[#B1B1B2] mt-[5%]">Year</p>
+                <p className="text-xs text-[#B1B1B2] mt-2">Year</p>
                 <h2>{year}</h2>
               </div>
-              <div className="flex flex-col">
-                <p className="text-xs text-[#B1B1B2] mt-[5%]">Passport No.</p>
+              <div>
+                <p className="text-xs text-[#B1B1B2]">Passport No.</p>
                 <h2>{passportNumber}</h2>
-                <p className="text-xs text-[#B1B1B2] mt-[5%]">Major</p>
+                <p className="text-xs text-[#B1B1B2] mt-2">Major</p>
                 <h2>{major}</h2>
               </div>
             </div>
           </div>
+        </div>
 
-          <div>
-            {!isSponsor && (
-              <div className="absolute bottom-1 left-1/2 transform -translate-y-1/2 -translate-x-1/2  w-full h-0.5 bg-[#DDC6A8]"></div>
-            )}
-          </div>
-
-          <div className="relative mt-[10%] p-[5%] ">
-            <h1 className="text-xl">Testimony</h1>
-            <p className="font-GT-Walsheim-Regular font-normal pt-2">{quote}</p>
-          </div>
+        {/* --- BOTTOM SECTION --- */}
+        <div className="p-4 md:p-6 lg:p-8">
+          <h1 className="text-lg md:text-xl">Testimony</h1>
+          <p className="font-GT-Walsheim-Regular font-normal pt-2 text-sm md:text-base leading-relaxed">
+            {quote}
+          </p>
         </div>
       </div>
     </div>

--- a/packages/ui/src/PassportCard.tsx
+++ b/packages/ui/src/PassportCard.tsx
@@ -26,7 +26,7 @@ export default function PassportCard({
   quote,
   image,
   isActive,
-}: PassportCardProps): React.ReactNode {
+}: PassportCardProps) {
   const positionClass = isActive ? "top-[20%]" : "top-[22%]";
   const scaleClass = isActive ? "scale-100" : "scale-[75%]";
 
@@ -39,10 +39,11 @@ export default function PassportCard({
       >
         {/* ─── TOP SECTION ─────────────────────────────────────────────── */}
         <div
-          className={`p-4 md:p-6 lg:p-8 ${!isSponsor ? "border-b border-[#DDC6A8]" : ""}`}
+          className={`p-4 md:p-6 lg:p-8 ${
+            !isSponsor ? "border-b border-[#DDC6A8]" : ""
+          }`}
         >
-          {" "}
-          {/* mobile = stacked | >=sm = side-by-side */}
+          {/* mobile = stacked | ≥sm = side-by-side */}
           <div className="flex flex-col sm:flex-row sm:items-start sm:space-x-4">
             {/* photo + header */}
             <div className="flex-shrink-0">

--- a/packages/ui/src/PassportCard.tsx
+++ b/packages/ui/src/PassportCard.tsx
@@ -16,7 +16,7 @@ export type PassportCardProps = {
 };
 
 export default function PassportCard({
-  isSponsor,
+  isSponsor = false,
   id,
   passportNumber,
   firstName,
@@ -33,52 +33,64 @@ export default function PassportCard({
   return (
     <div className="flex justify-center items-center w-full font-GT-Walsheim-Pro-Regular font-bold">
       <div
-        className={`bg-white rounded-3xl shadow-[0_15px_0px_-5px_rgba(221,198,168,1)] ${scaleClass} absolute ${positionClass} transition-all w-[30%] sm:w-[60%] md:w-[45%] lg:w-[30%]`}
+        className={`bg-white rounded-3xl shadow-[0_15px_0px_-5px_rgba(221,198,168,1)]
+                    ${scaleClass} absolute ${positionClass} transition-all duration-300
+                    w-[85%] max-w-[320px] sm:max-w-[360px] sm:w-[60%] md:w-[45%] lg:w-[30%]`}
       >
-        {/* --- TOP SECTION --- */}
-        <div className="p-4 md:p-6 lg:p-8 border-b border-[#DDC6A8]">
-          <div className="flex items-start space-x-4">
-            {/* Left side: photo and passport header */}
+        {/* ─── TOP SECTION ─────────────────────────────────────────────── */}
+        <div
+          className={`p-4 md:p-6 lg:p-8 ${!isSponsor ? "border-b border-[#DDC6A8]" : ""}`}
+        >
+          {" "}
+          {/* mobile = stacked | >=sm = side-by-side */}
+          <div className="flex flex-col sm:flex-row sm:items-start sm:space-x-4">
+            {/* photo + header */}
             <div className="flex-shrink-0">
               <div className="flex items-center space-x-2 mb-4">
                 <Image
                   alt="passport icon"
-                  src={"/passport_icon.svg"}
-                  width={32}
-                  height={32}
+                  src="/passport_icon.svg"
+                  width={24}
+                  height={24}
                 />
                 <h1 className="text-lg md:text-xl">PASSPORT</h1>
               </div>
               <Image
                 alt={`${firstName}${lastName}${id}`}
                 src={image}
-                width={100}
-                height={100}
-                className="rounded-md object-cover"
+                width={120}
+                height={120}
+                className="rounded-md object-cover w-[120px] h-[120px]"
               />
             </div>
 
-            {/* Right side: personal info */}
-            <div className="flex-grow flex flex-col sm:flex-row sm:justify-between w-full space-y-2 sm:space-y-0 sm:space-x-6">
+            {/* personal info */}
+            <div className="mt-4 sm:mt-0 flex-grow grid grid-cols-2 gap-x-4 gap-y-2 text-[14px]">
               <div>
                 <p className="text-xs text-[#B1B1B2]">First name</p>
                 <h2>{firstName.toUpperCase()}</h2>
-                <p className="text-xs text-[#B1B1B2] mt-2">Last name</p>
-                <h2>{lastName.toUpperCase()}</h2>
-                <p className="text-xs text-[#B1B1B2] mt-2">Year</p>
-                <h2>{year}</h2>
               </div>
               <div>
-                <p className="text-xs text-[#B1B1B2]">Passport No.</p>
+                <p className="text-xs text-[#B1B1B2]">Passport&nbsp;No.</p>
                 <h2>{passportNumber}</h2>
-                <p className="text-xs text-[#B1B1B2] mt-2">Major</p>
+              </div>
+              <div>
+                <p className="text-xs text-[#B1B1B2]">Last name</p>
+                <h2>{lastName.toUpperCase()}</h2>
+              </div>
+              <div>
+                <p className="text-xs text-[#B1B1B2]">Major</p>
                 <h2>{major}</h2>
+              </div>
+              <div>
+                <p className="text-xs text-[#B1B1B2]">Year</p>
+                <h2>{year}</h2>
               </div>
             </div>
           </div>
         </div>
 
-        {/* --- BOTTOM SECTION --- */}
+        {/* ─── BOTTOM SECTION ──────────────────────────────────────────── */}
         <div className="p-4 md:p-6 lg:p-8">
           <h1 className="text-lg md:text-xl">Testimony</h1>
           <p className="font-GT-Walsheim-Regular font-normal pt-2 text-sm md:text-base leading-relaxed">

--- a/packages/ui/src/PassportCard.tsx
+++ b/packages/ui/src/PassportCard.tsx
@@ -37,7 +37,7 @@ export default function PassportCard({
                     ${scaleClass} absolute ${positionClass} transition-all duration-300
                     w-[85%] max-w-[320px] sm:max-w-[360px] sm:w-[60%] md:w-[45%] lg:w-[30%]`}
       >
-        {/* ─── TOP SECTION ─────────────────────────────────────────────── */}
+        {/* ─── TOP SECTION */}
         <div
           className={`p-4 md:p-6 lg:p-8 ${
             !isSponsor ? "border-b border-[#DDC6A8]" : ""
@@ -91,7 +91,7 @@ export default function PassportCard({
           </div>
         </div>
 
-        {/* ─── BOTTOM SECTION ──────────────────────────────────────────── */}
+        {/* ─── BOTTOM SECTION */}
         <div className="p-4 md:p-6 lg:p-8">
           <h1 className="text-lg md:text-xl">Testimony</h1>
           <p className="font-GT-Walsheim-Regular font-normal pt-2 text-sm md:text-base leading-relaxed">


### PR DESCRIPTION
# <Summary line - One sentence describing your intended set of changes>

## 🎫 Issue #111.

## 🎨 Figma Link <optional>: https://www.figma.com/design/xkYK4nbALjkUNW5Ikl8FYH/Roadtrip-Website-Wireframes?node-id=398-134

### ▶ Changelist:

- Top and bottom halves of the card are split into separate containers (top-section, bottom-section)
- Added responsive styling using Tailwind’s responsive classes 
- Added a mobile-friendly layout for smaller screen widths (w-full, flex-col, adjusted paddings, and spacing)
- Make visual separation between ID and testimonial remains clean and accessible on all screen sizes

### 📝 Notes + 🚧 TODO:

- Added a template file at 'apps/main/src/pages/_document.tsx' to satisfy the file dependency so that the lint is successful 
- Removed the function para 'isSponsor' since it's no longer needed..

### 🧪 Testing:

- Unit + manual (since it's design focus ish)
- :)

### 🎥 Screenshots & Screencasts:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d56f93ac-5c2a-48ed-b82e-135a55f0aeaa" />

Looking pretty and close to Figma design :)
