### PR TITLE
created sponsor us page and users can navigate to it

### DIFF
--- a/apps/main/src/app/(landing)/Sections/SponsorUs.tsx
+++ b/apps/main/src/app/(landing)/Sections/SponsorUs.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const SponsorUs = () => {
+  return (
+    <div >
+      <h1 className="text-3xl font-bold mb-6">Sponsor Us</h1>
+      <p className="text-lg text-gray-600">
+        Sponsor Us page placeholder.
+      </p>
+    </div>
+  );
+};
+
+export default SponsorUs;

--- a/apps/main/src/app/lib/Components/NavBar.tsx
+++ b/apps/main/src/app/lib/Components/NavBar.tsx
@@ -33,7 +33,7 @@ const NavBar = () => {
             Team
           </LocalLink>
           <LocalLink
-            href={"#sponsor-us"}
+            href={"/sponsor-us"}
             className="bg-orange text-xl flex items-center px-5 text-text-light"
           >
             Sponsor Us

--- a/apps/main/src/app/sponsor-us/page.tsx
+++ b/apps/main/src/app/sponsor-us/page.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import SponsorUs from '../../app/(landing)/Sections/SponsorUs';
+
+const SponsorUsPage = () => {
+  return <SponsorUs />;
+};
+
+export default SponsorUsPage;


### PR DESCRIPTION
# Created the sponsor-us page and made it possible for users to navigate to it. 

## 🎫 Issue #125 

### ▶ Changelist:

- created a sponsor-us folder with page.tsx 
- created SponsorUs.tsx in Sections folder 
- edited the NavBar component to direct to the sponsor-us folder 

### 📝 Notes + 🚧 TODO:

- this ticket does not include any changes, design or implementations to the sponsor us page. the user should just be able to be directed to this page.

### 🧪 Testing:

- user should be able to click on the sponsor us button and be directed to a new sponsor us page. 

### 🎥 Screenshots & Screencasts:
<img width="1309" alt="Screenshot 2025-06-21 at 8 36 07 PM" src="https://github.com/user-attachments/assets/d8affa51-2e6a-4304-a924-d5c7ec4646a1" />
