### PR TITLE
Sk/about page fixes

### DIFF
--- a/apps/main/src/app/(landing)/Sections/About.tsx
+++ b/apps/main/src/app/(landing)/Sections/About.tsx
@@ -27,7 +27,7 @@ export default function About(): React.ReactNode {
       </div>
       <div
         className="absolute transform
-                   w-[373.15px] h-[220.91px] left-[28px] top-[1630px] 
+                   w-[373.15px] h-[220.91px] left-[55px] top-[1270px] 
                    scale-[1.9] rotate-[0] origin-left
                    tablet:absolute tablet:w-[45vw] tablet:left-[58vw] tablet:right-0 
                    tablet:transform tablet:-rotate-[7.5deg] tablet:top-[210vh] tablet:scale-[2.2]"
@@ -37,21 +37,21 @@ export default function About(): React.ReactNode {
       {/* the journal parts*/}
       <div
         className="absolute 
-                 left-[280px] scale-[1.15] rotate-[0] top-[1550px] mt-0
+                 left-[280px] scale-[1.0] rotate-[0] top-[1190px] mt-0
                  tablet:left-[94%] tablet:scale-[2.7] tablet:-rotate-[7.5deg] tablet:top-[185vh] tablet:mt-24"
       >
         <Image alt="AboutPicture" src="/about_1.png" width={250} height={100} />
       </div>
       <div
         className="absolute 
-                 left-[245px] scale-[0.75] rotate-[0] top-[1645px]
+                 left-[265px] scale-[0.75] rotate-[0] top-[1297px]
                  tablet:absolute tablet:left-[96%] tablet:mt-96 tablet:scale-[3.8] tablet:-rotate-[7.5deg] tablet:top-[175vh]"
       >
         <Image alt="AboutPicture" src="/about_2.png" width={350} height={200} />
       </div>
       <div
         className="absolute
-                 w-[148.2px] h-[94.89px] left-[50.46px] top-[1575px] scale-[1.08] rotate-[7.5deg]
+                 w-[148.2px] h-[94.89px] left-[70.46px] top-[1235px] scale-[1.08] rotate-[7.5deg]
                  tablet:absolute tablet:w-[45vw] tablet:h-auto tablet:left-[60vw] tablet:top-[173vh] tablet:mt-48 tablet:scale-100 tablet:rotate-0"
       >
         <Image alt="AboutPicture" src="/about_3.png" width={300} height={300} />
@@ -59,36 +59,38 @@ export default function About(): React.ReactNode {
 
       <div
         className="absolute 
-                 left-[80.46px] top-[1555px] scale-[0.45]
+                 left-[90.46px] top-[1215px] scale-[0.45]
                  tablet:absolute tablet:left-[63vw] tablet:top-[173vh] tablet:mt-48 tablet:scale-100"
       >
         <Thumbtack1 />
       </div>
       <div
         className="absolute 
-                 left-[294px] scale-[0.45] top-[1630px]
+                 left-[324px] scale-[0.45] top-[1285px]
                  tablet:absolute tablet:left-[94%] tablet:top-[163vh] tablet:mt-96 tablet:scale-100"
       >
         <Thumbtack2 />
       </div>
       <div
         className="absolute 
-                 left-[300px] scale-[0.45] top-[1520px]
+                 left-[300px] scale-[0.45] top-[1170px]
                  tablet:absolute tablet:left-[94%] tablet:top-[177vh] tablet:mt-28 tablet:scale-100"
       >
         <Thumbtack3 />
       </div>
-      <div className="absolute h-full w-[50vw] ml-24 mr-auto mt-5 tablet:mt-24 flex text-[1.8vw]">
+      <div className="absolute h-full w-[50vw] ml-20 mr-auto mt-5 tablet:ml-24 tablet:mt-24 flex text-[1.8vw]">
         <div className="w-[50vw]">
-          <StreetSign streetName={"ABOUT"} suffix="HBP" />
-          <div>
+          <div className="scale-75 origin-left -ml-4 tablet:scale-100 tablet:ml-0">
+            <StreetSign streetName={"ABOUT"} suffix="HBP" />
+          </div>
+          <div className="mt-8 tablet:mt-4">
             <AboutParagraph />
           </div>
           <button
             className="mt-0 absolute top-[30%] bg-[#02877F] text-white rounded-[64px] text-xs flex items-center justify-center
-                                relative top-[265px] w-[162.48px] h-[31.59px] right-[50px]
+                                relative top-[310px] w-[162.48px] h-[31.59px] right-[50px]
                                 tablet:mt-12 tablet:top-auto tablet:w-auto tablet:h-auto tablet:right-auto
-                                tablet:w-[278.17px] tablet:h-[67.69px] tablet:!text-[26.5px]"
+                                tablet:w-[298.17px] tablet:h-[77.69px] tablet:!text-[26.5px]"
           >
             {"View Past Photos"}
           </button>

--- a/apps/main/src/app/(landing)/Sections/About.tsx
+++ b/apps/main/src/app/(landing)/Sections/About.tsx
@@ -90,7 +90,7 @@ export default function About(): React.ReactNode {
             className="mt-0 absolute top-[30%] bg-[#02877F] text-white rounded-[64px] text-xs flex items-center justify-center
                                 relative top-[310px] w-[162.48px] h-[31.59px] right-[50px]
                                 tablet:mt-12 tablet:top-auto tablet:w-auto tablet:h-auto tablet:right-auto
-                                tablet:w-[298.17px] tablet:h-[77.69px] tablet:!text-[26.5px]"
+                                tablet:w-[308.17px] tablet:h-[67.69px] tablet:!text-[26.5px]"
           >
             {"View Past Photos"}
           </button>

--- a/apps/main/src/app/(landing)/Sections/About.tsx
+++ b/apps/main/src/app/(landing)/Sections/About.tsx
@@ -27,10 +27,10 @@ export default function About(): React.ReactNode {
       </div>
       <div
         className="absolute transform
-                   w-[373.15px] h-[220.91px] left-[55px] top-[1270px] 
+                   w-[373.15px] h-[220.91px] left-[55px]
                    scale-[1.9] rotate-[0] origin-left
                    tablet:absolute tablet:w-[45vw] tablet:left-[58vw] tablet:right-0 
-                   tablet:transform tablet:-rotate-[7.5deg] tablet:top-[210vh] tablet:scale-[2.2] mobile:mt-14"
+                   tablet:transform tablet:-rotate-[7.5deg] tablet:top-[200vh] tablet:scale-[2.2] mobile:mt-14"
       >
         <Journal />
       </div>
@@ -96,8 +96,8 @@ export default function About(): React.ReactNode {
           </button>
         </div>
         <div
-          className="absolute pb-0 top-[77vh]
-                 w-[560.34px] h-[132.06px] left-[-160.67px] top-[447.5px]
+          className="absolute bottom-auto
+                 w-[560.34px] h-[132.06px] left-[-160.67px] 
                  tablet:absolute tablet:w-[312px] tablet:h-auto tablet:left-[66%] 
                  tablet:bottom-auto tablet:top-[70vh] tablet:scale-[3.3] mobile:mt-5 mobile:ml-5"
         >

--- a/apps/main/src/app/(landing)/Sections/About.tsx
+++ b/apps/main/src/app/(landing)/Sections/About.tsx
@@ -30,7 +30,7 @@ export default function About(): React.ReactNode {
                    w-[373.15px] h-[220.91px] left-[55px] top-[1270px] 
                    scale-[1.9] rotate-[0] origin-left
                    tablet:absolute tablet:w-[45vw] tablet:left-[58vw] tablet:right-0 
-                   tablet:transform tablet:-rotate-[7.5deg] tablet:top-[210vh] tablet:scale-[2.2]"
+                   tablet:transform tablet:-rotate-[7.5deg] tablet:top-[210vh] tablet:scale-[2.2] mobile:mt-14"
       >
         <Journal />
       </div>
@@ -38,21 +38,21 @@ export default function About(): React.ReactNode {
       <div
         className="absolute 
                  left-[280px] scale-[1.0] rotate-[0] top-[1190px] mt-0
-                 tablet:left-[94%] tablet:scale-[2.7] tablet:-rotate-[7.5deg] tablet:top-[185vh] tablet:mt-24"
+                 tablet:left-[94%] tablet:scale-[2.7] tablet:-rotate-[7.5deg] tablet:top-[185vh] tablet:mt-24 mobile:mt-14"
       >
         <Image alt="AboutPicture" src="/about_1.png" width={250} height={100} />
       </div>
       <div
         className="absolute 
                  left-[265px] scale-[0.75] rotate-[0] top-[1297px]
-                 tablet:absolute tablet:left-[96%] tablet:mt-96 tablet:scale-[3.8] tablet:-rotate-[7.5deg] tablet:top-[175vh]"
+                 tablet:absolute tablet:left-[96%] tablet:mt-96 tablet:scale-[3.8] tablet:-rotate-[7.5deg] tablet:top-[175vh] mobile:mt-14"
       >
         <Image alt="AboutPicture" src="/about_2.png" width={350} height={200} />
       </div>
       <div
         className="absolute
                  w-[148.2px] h-[94.89px] left-[70.46px] top-[1235px] scale-[1.08] rotate-[7.5deg]
-                 tablet:absolute tablet:w-[45vw] tablet:h-auto tablet:left-[60vw] tablet:top-[173vh] tablet:mt-48 tablet:scale-100 tablet:rotate-0"
+                 tablet:absolute tablet:w-[45vw] tablet:h-auto tablet:left-[60vw] tablet:top-[173vh] tablet:mt-48 tablet:scale-100 tablet:rotate-0 mobile:mt-14"
       >
         <Image alt="AboutPicture" src="/about_3.png" width={300} height={300} />
       </div>
@@ -60,21 +60,21 @@ export default function About(): React.ReactNode {
       <div
         className="absolute 
                  left-[90.46px] top-[1215px] scale-[0.45]
-                 tablet:absolute tablet:left-[63vw] tablet:top-[173vh] tablet:mt-48 tablet:scale-100"
+                 tablet:absolute tablet:left-[63vw] tablet:top-[173vh] tablet:mt-48 tablet:scale-100 mobile:mt-14"
       >
         <Thumbtack1 />
       </div>
       <div
         className="absolute 
                  left-[324px] scale-[0.45] top-[1285px]
-                 tablet:absolute tablet:left-[94%] tablet:top-[163vh] tablet:mt-96 tablet:scale-100"
+                 tablet:absolute tablet:left-[94%] tablet:top-[163vh] tablet:mt-96 tablet:scale-100 mobile:mt-14"
       >
         <Thumbtack2 />
       </div>
       <div
         className="absolute 
                  left-[300px] scale-[0.45] top-[1170px]
-                 tablet:absolute tablet:left-[94%] tablet:top-[177vh] tablet:mt-28 tablet:scale-100"
+                 tablet:absolute tablet:left-[94%] tablet:top-[177vh] tablet:mt-28 tablet:scale-100 mobile:mt-14"
       >
         <Thumbtack3 />
       </div>
@@ -87,10 +87,10 @@ export default function About(): React.ReactNode {
             <AboutParagraph />
           </div>
           <button
-            className="mt-0 absolute top-[30%] bg-[#02877F] text-white rounded-[64px] text-xs flex items-center justify-center
-                                relative top-[310px] w-[162.48px] h-[31.59px] right-[50px]
+            className="font-GT-Walsheim-Regular mt-0 absolute top-[30%] bg-[#02877F] text-white rounded-[64px] text-xs flex items-center justify-center
+                                relative top-[310px] desktop:w-[235.22px] desktop:h-[64.05px] right-[50px]
                                 tablet:mt-12 tablet:top-auto tablet:w-auto tablet:h-auto tablet:right-auto
-                                tablet:w-[308.17px] tablet:h-[67.69px] tablet:!text-[26.5px]"
+                                tablet:w-[308.17px] tablet:h-[67.69px] tablet:!text-[26.5px] mobile:w-[162.48px] mobile:h-[31.59px]"
           >
             {"View Past Photos"}
           </button>
@@ -99,7 +99,7 @@ export default function About(): React.ReactNode {
           className="absolute pb-0 top-[77vh]
                  w-[560.34px] h-[132.06px] left-[-160.67px] top-[447.5px]
                  tablet:absolute tablet:w-[312px] tablet:h-auto tablet:left-[66%] 
-                 tablet:bottom-auto tablet:top-[70vh] tablet:scale-[3.3] "
+                 tablet:bottom-auto tablet:top-[70vh] tablet:scale-[3.3] mobile:mt-5 mobile:ml-5"
         >
           <Cities />
         </div>

--- a/apps/main/src/app/(landing)/Sections/Keynote.tsx
+++ b/apps/main/src/app/(landing)/Sections/Keynote.tsx
@@ -51,11 +51,11 @@ function SpeakerPhoto({
   );
 }
 
-function SpeakerDetails({
-  textAlign,
-}: SpeakerDetailsProps): JSX.Element {
+function SpeakerDetails({ textAlign }: SpeakerDetailsProps): JSX.Element {
   return (
-    <div className={`desktop:mt-[15%] desktop:ml-2 desktop:mr-[-15%] mobile:mt-[-5%] mobile:ml-[-10%] mobile:mr-[10%] font-GT-Walsheim-Regular ${textAlign}`}>
+    <div
+      className={`desktop:mt-[15%] desktop:ml-2 desktop:mr-[-15%] mobile:mt-[-5%] mobile:ml-[-10%] mobile:mr-[10%] font-GT-Walsheim-Regular ${textAlign}`}
+    >
       {/* <p
         className={`text-[1.75vw] scale-[${scaleFactor}] font-bold ${bottomMargin}`}
       >
@@ -65,12 +65,8 @@ function SpeakerDetails({
         3rd year Computer Science student, Stevens Institute of Technology |
         Tech Content Creator
       </p> */}
-      <p
-        className="desktop:text-3xl mobile:text-xl font-bold"
-      >
-        Aidan Ouckama
-      </p>
-      <p className='desktop:text-2xl text-lightBrown desktop:static mobile:absolute '>
+      <p className="desktop:text-3xl mobile:text-xl font-bold">Aidan Ouckama</p>
+      <p className="desktop:text-2xl text-lightBrown desktop:static mobile:absolute ">
         3rd year Computer Science student, Stevens Institute of Technology |
         Tech Content Creator
       </p>
@@ -117,7 +113,9 @@ export default function Keynote(): React.ReactNode {
   }`;
 
   return (
-    <div className={`w-full bg-cream ${isMobile ? "h-auto" : "h-[120vh]"} mobile:pb-10`}>
+    <div
+      className={`w-full bg-cream ${isMobile ? "h-auto" : "h-[120vh]"} mobile:pb-10`}
+    >
       <div className={conditionalAlignment}>
         <div className={`${isMobile ? "w-[80vw]" : "w-[55vw]"}`}>
           {isMobile && (
@@ -143,7 +141,9 @@ export default function Keynote(): React.ReactNode {
           </div>
         </div>
 
-        <div className={`${isMobile ? "w-[80vw]" : "w-[55vw] mr-[5%] sm:scale-[0.5]"}`}>
+        <div
+          className={`${isMobile ? "w-[80vw]" : "w-[55vw] mr-[5%] sm:scale-[0.5]"}`}
+        >
           {!isMobile && <StreetSign streetName="KEYNOTE" suffix="SPEAKER" />}
           <SpeakerAbout additionalClasses={`${isMobile ? "text-left" : ""}`} />
         </div>

--- a/apps/main/src/app/lib/Assets/SVG/AboutAssets/AboutParagraph.tsx
+++ b/apps/main/src/app/lib/Assets/SVG/AboutAssets/AboutParagraph.tsx
@@ -9,6 +9,7 @@ const AboutParagraph = () => {
     font-GT-Walsheim-Regular 
     mt-6 tablet:mt-12
     text-left 
+    w-[70vw]
     text-[11px]               
     tablet:text-3xl           
     tablet:max-w-full


### PR DESCRIPTION
# About Page Layout & Button Bug Fix

## 🎫 Issue #132  AND #128 .

## 🎨 [Figma Link <optional>](https://www.figma.com/design/xkYK4nbALjkUNW5Ikl8FYH/Roadtrip-Website-Wireframes?node-id=408-153&t=bY1oDKxNJvUGrTs9-0):

### ▶ Changelist:

- Added some styling to fix the layout of the About page to match the layout of the Figma
- Fixed the 'View Past Photos' button to be the correct size on desktop view. 

### 📝 Notes + 🚧 TODO:

- This PR addresses TWO tickets. It addresses the [About section button ](https://github.com/orgs/HackBeanpot/projects/16/views/3?filterQuery=&pane=issue&itemId=115541307&issue=HackBeanpot%7Ccore%7C128) AND [About page fixes](https://github.com/orgs/HackBeanpot/projects/16/views/3?filterQuery=&pane=issue&itemId=116660531&issue=HackBeanpot%7Ccore%7C132). I fixed the mobile design for the page and addressed a bug with a button on desktop view.
- Make sure to test both tickets/fixes!!!

### 🧪 Testing:

- Test both on desktop and mobile (I did 415 x 684) to make sure the layout and button sizes look correct on both!!
