### PR TITLE
Sg/mobile view 163

### DIFF
--- a/apps/main/src/app/projects/content.tsx
+++ b/apps/main/src/app/projects/content.tsx
@@ -99,7 +99,7 @@ const ProjectsContent = forwardRef<HTMLDivElement>((_, ref) => {
           />
         </a>
       </section>
-      <div className="flex justify-center items-center flex-col font-GT-Walsheim-Regular bg-[#FFF8EF] p-10 rounded-3xl mr-[2rem] ml-[2rem] drop-shadow-[0_8px_0px_rgba(0,0,0,.1)]">
+      <div className="flex justify-center items-center flex-col font-GT-Walsheim-Regular bg-[#FFF8EF] p-10 rounded-3xl mr-[2rem] ml-[2rem] mb-[8rem] [@media(max-width:640px)]:mb-[12rem]">
         <div className="flex justify-center items-center flex-col">
           <h3 className="text-center text-3xl mb-[1rem] font-bold">
             Interested in seeing more Past Hacker Projects?

--- a/apps/main/src/app/projects/content.tsx
+++ b/apps/main/src/app/projects/content.tsx
@@ -10,7 +10,7 @@ const ProjectsContent = forwardRef<HTMLDivElement>((_, ref) => {
         </h1>
       </div>
       <section
-        className="grid gap-5 mb-[5rem] max-w-[1200px] mx-auto
+        className="grid gap-5 mb-[2rem] max-w-[1200px] mx-auto
         [@media(max-width:640px)]:grid-cols-1
         grid-cols-[repeat(auto-fit,minmax(300px,1fr))]"
       >
@@ -99,7 +99,7 @@ const ProjectsContent = forwardRef<HTMLDivElement>((_, ref) => {
           />
         </a>
       </section>
-      <div className="flex justify-center items-center flex-col font-GT-Walsheim-Regular bg-[#FFF8EF] p-10 rounded-3xl mr-[2rem] ml-[2rem] mb-[8rem] [@media(max-width:640px)]:mb-[12rem]">
+      <div className="flex justify-center items-center flex-col font-GT-Walsheim-Regular bg-[#FFF8EF] p-10 rounded-3xl mr-[2rem] ml-[3rem] mb-0 [@media(max-width:640px)]:mb-[16rem]">
         <div className="flex justify-center items-center flex-col">
           <h3 className="text-center text-3xl mb-[1rem] font-bold">
             Interested in seeing more Past Hacker Projects?


### PR DESCRIPTION
#Bottom of projects page gets cut off in mobile view 
## 🎫 Issue #163 

## 🎨 [Figma Link ](https://www.figma.com/design/xkYK4nbALjkUNW5Ikl8FYH/Roadtrip-Website-Wireframes?node-id=285-128&t=ClByNGoYJr4G6MFt-0)

### ▶ Changelist:

- pushed down the Ford F150 truck 

### 📝 Notes + 🚧 TODO:

- one line changer 

### 🧪 Testing:

- tested w mobile screen 

### 🎥 Screenshots & Screencasts:
<img width="440" height="889" alt="Screenshot 2025-07-21 at 8 30 27 PM" src="https://github.com/user-attachments/assets/868f0b0b-2a93-46e9-a75e-c7ce2b2f490d" />

