### PR TITLE
Sk/stats section

### DIFF
--- a/apps/main/src/app/(landing)/Sections/Stats.tsx
+++ b/apps/main/src/app/(landing)/Sections/Stats.tsx
@@ -2,22 +2,22 @@ import React from "react";
 import Box from "@repo/ui/Box";
 
 export default function Stats(): React.ReactNode {
-  return (
-    <div className="w-full">
-      <div className="w-full bg-[#BEACD0] p-16 flex flex-row gap-16 justify-center content-center text-xl tablet:text-3xl">
-        <Box>
-          <p className="text-4xl tablet:text-7xl font-medium mb-2">{"10+"}</p>
-          <p>{"years of HBP"}</p>
-        </Box>
-        <Box>
-          <p className="text-4xl tablet:text-7xl font-medium mb-2">{"10+"}</p>
-          <p>{"sponsors each year"}</p>
-        </Box>
-        <Box>
-          <p className="text-4xl tablet:text-7xl font-medium mb-2">{"800+"}</p>
-          <p>{"beans and counting"}</p>
-        </Box>
-      </div>
-    </div>
-  );
+ return (
+   <div className="w-full">
+     <div className="w-full bg-[#BEACD0] p-4 desktop:p-16 flex flex-row gap-4 desktop:gap-16 justify-center content-center text-xl desktop:text-3xl">
+       <Box>
+        <p className="mobile:text-xl desktop:text-4xl font-medium mb-2">{"10+"}</p>
+        <p className="mobile:text-sm desktop:text-xl">{"years of HBP"}</p>
+       </Box>
+       <Box>
+         <p className="mobile:text-xl desktop:text-4xl font-medium mb-2">{"10+"}</p>
+         <p className="mobile:text-sm desktop:text-xl">{"sponsors each year"}</p>
+       </Box>
+       <Box>
+         <p className="mobile:text-xl desktop:text-4xl font-medium mb-2">{"800+"}</p>
+         <p className="mobile:text-sm desktop:text-xl">{"beans and counting"}</p>
+       </Box>
+     </div>
+   </div>
+ );
 }

--- a/packages/ui/src/Box.tsx
+++ b/packages/ui/src/Box.tsx
@@ -6,7 +6,7 @@ type BoxProps = {
 
 export default function Box({ children }: BoxProps) {
   return (
-    <div className="py-[4%] p-[2%] rounded-lg w-full text-center  tablet:max-w-[26vw] tablet:max-h-[13vw] text-[#474747] flex flex-col justify-center bg-[#FBFBFB] shadow-lg">
+    <div className="py-[4%] p-[2%] rounded-lg w-full desktop:max-w-[25vw] text-center text-[#474747] flex flex-col justify-center bg-[#FBFBFB] shadow-lg">
       {children}
     </div>
   );

--- a/packages/ui/src/Box.tsx
+++ b/packages/ui/src/Box.tsx
@@ -6,7 +6,7 @@ type BoxProps = {
 
 export default function Box({ children }: BoxProps) {
   return (
-    <div className="py-[4%] p-[2%] rounded-lg w-full max-w-[25vw] max-h-[28vh] text-center text-[#474747] flex flex-col justify-center bg-[#FBFBFB] shadow-lg">
+    <div className="py-[4%] p-[2%] rounded-lg w-full text-center  tablet:max-w-[26vw] tablet:max-h-[13vw] text-[#474747] flex flex-col justify-center bg-[#FBFBFB] shadow-lg">
       {children}
     </div>
   );


### PR DESCRIPTION
# Stats Section Mobile View 

## 🎫 Issue #158 .

## 🎨 [Figma](https://www.figma.com/design/xkYK4nbALjkUNW5Ikl8FYH/Roadtrip-Website-Wireframes?node-id=247-108&t=RXSCQDCHCU8FxzSe-0)

### ▶ Changelist:

- Implemented the mobile view for the stats section
- Investigated why the section disappears + implemented fix

### 🧪 Testing:

- Test the desktop and mobile view and make sure the stats section doesn't disappear and generally matches the figma designs!
