### PR TITLE
fixed sponsor background

### DIFF
--- a/apps/main/src/app/sponsors/background.tsx
+++ b/apps/main/src/app/sponsors/background.tsx
@@ -8,7 +8,7 @@ const SponsorsBackground = () => {
   const { isMobile } = useContext(MobileContext);
 
   return (
-    <div className="w-full h-full overflow-hidden">
+    <div className="w-full h-full overflow-visible">
       <Image
         alt="Sponsors Background"
         src={

--- a/apps/main/src/app/sponsors/content.tsx
+++ b/apps/main/src/app/sponsors/content.tsx
@@ -60,7 +60,7 @@ const SponsorsContent = forwardRef<HTMLDivElement>((_, ref) => {
           />
         </div>
       </div>
-      <div className="top-[101%] bg-[#C6E0D3] w-full h-[15%] absolute bottom-0 flex justify-center items-center flex-col space-y-4 font-GT-Walsheim-Regular p-28">
+      <div className="bg-[#C6E0D3] mobile:w-full desktop:w-[150%] flex justify-center items-center flex-col space-y-4 font-GT-Walsheim-Regular py-20 px-4 mt-20">
         <h1 className="text-2xl font-GT-Walsheim-Bold text-center">
           Interested in sponsoring HackBeanpot 2025?
         </h1>

--- a/apps/main/src/app/sponsors/page.tsx
+++ b/apps/main/src/app/sponsors/page.tsx
@@ -5,24 +5,35 @@ import SponsorsBackground from "./background";
 import SponsorsContent from "./content";
 import React, { useRef } from "react";
 import useWindowSize from "@util/hooks/useWindowSize";
+import useContentHeight from "@util/hooks/useContentHeight";
 
 export default function Page(): JSX.Element {
   const ref = useRef<HTMLDivElement>(null);
   const { height: windowHeight, width: windowWidth } = useWindowSize();
+  const [contentHeight] = useContentHeight(ref);
 
   if (!windowHeight || !windowWidth) return <></>;
 
+  const mainHeight = Math.max(contentHeight, windowHeight);
+
   return (
-    <main className="flex flex-col items-center min-h-screen">
-      <div className="absolute inset-0 w-full h-full z-0 pointer-events-none">
+    <main
+      className="flex flex-col items-center min-h-screen relative"
+      style={{ minHeight: mainHeight }}
+    >
+      <div className="absolute inset-0 w-full h-[90%] z-0 pointer-events-none">
         <SponsorsBackground />
       </div>
-      <div className="relative z-10 w-full flex flex-col items-center mb-48">
+      <div
+        className="relative z-10 w-full flex flex-col items-center"
+        ref={ref}
+      >
         <NavBar />
-        <SponsorsContent ref={ref} />
+        <SponsorsContent />
+        <div>
+          <Footer />
+        </div>
       </div>
-
-      <Footer />
     </main>
   );
 }


### PR DESCRIPTION
# <Summary line - One sentence describing your intended set of changes>
Fixed bug that prevented sponsor background from scaling properly to different screen sizes
## 🎫 Issue #<bug number>.

## 🎨 Figma Link <optional>:
https://www.figma.com/design/xkYK4nbALjkUNW5Ikl8FYH/Roadtrip-Website-Wireframes?node-id=285-128&t=qWSv7AdJxeF5rExq-0

### ▶ Changelist:

-Refactored sponsor page so that the footer background would not exceed its intended height
- implemented functionality to use window height for better placing of components

### 🧪 Testing:

- manual testing on screens using dev tools

### 🎥 Screenshots & Screencasts:

<img width="1792" height="1120" alt="Screenshot 2025-08-07 at 1 17 23 PM" src="https://github.com/user-attachments/assets/cfa48633-00f0-45b3-b414-9efe3712966c" />
<img width="1792" height="1120" alt="Screenshot 2025-08-07 at 1 17 40 PM" src="https://github.com/user-attachments/assets/a7b8fc91-857b-44bc-9065-f55778366136" />

