### PR TITLE
mainsite/bugfix/view-sponsorship-packet-button-fixed

### DIFF
--- a/apps/main/src/app/sponsor-us/Sections/SponsorTop.tsx
+++ b/apps/main/src/app/sponsor-us/Sections/SponsorTop.tsx
@@ -30,7 +30,7 @@ const SponsorTop = () => {
           color="firecrackerRed"
           size="medium"
           onClick={() =>
-            window.open("https://archive.hackbeanpot.com/", "_blank")
+            window.open("https://drive.google.com/file/d/1MNIE0Tgme3mkMVg26E9VZPQQ8i37-VqL/view?usp=sharing", "_blank")
           }
         />
       </div>


### PR DESCRIPTION
# Fixed the "View Sponsorship Packet" Button on the Sponsor Us Page

## 🎫 Issue #280 .

## 🎨 Figma Link: https://www.figma.com/design/oqaBHJmfuH0Tf46TulyVV0/-Design--Mainsite?node-id=0-1&p=f&t=NLB2GhSUqqgLbiDr-0

### ▶ Changelist:

- Fixed the button so that it links to the sponsorship packet in the Google Drive: https://drive.google.com/file/d/1MNIE0Tgme3mkMVg26E9VZPQQ8i37-VqL/view?usp=sharing

### 📝 Notes + 🚧 TODO:

- Put the sponsorship packet (got from Alina) into the Google Drive
- ** NOT SURE IF PEOPLE OUTSIDE THE ORGANIZATION CAN ACCESS THE FILE!! (access restrictions are currently set to:
<img width="488" height="104" alt="Screenshot 2025-10-30 at 6 09 26 PM" src="https://github.com/user-attachments/assets/492cbfbd-c25a-4b18-a1f8-f2b924569706" />
- unable to change it to anything outside hackbeanpot.com/the organization (needs to be tested if can access outside org.!)


### 🧪 Testing:

- Tested locally on desktop/localhost

### 🎥 Screenshots & Screencasts:

<img width="899" height="622" alt="Screenshot 2025-10-30 at 6 04 46 PM" src="https://github.com/user-attachments/assets/94eb8cab-f40a-4ff3-b693-4b10a9547af8" />
<img width="1470" height="799" alt="Screenshot 2025-10-30 at 6 04 57 PM" src="https://github.com/user-attachments/assets/dad71d60-ba90-4b45-b6f0-1ac04383c587" />

