### PR TITLE
added -mt styling for hero section

### DIFF
--- a/apps/main/src/app/lib/Assets/SVG/OurTeamAssets/hero.tsx
+++ b/apps/main/src/app/lib/Assets/SVG/OurTeamAssets/hero.tsx
@@ -3,7 +3,7 @@ import HeroBackground from "./heroBackground";
 
 export default function Hero() {
   return (
-    <section className="relative w-full overflow-hidden">
+    <section className="relative w-full overflow-hidden -mt-[1vh]">
       <HeroBackground />
 
       <svg


### PR DESCRIPTION
# Added -mt styling for hero section to remove small gap

## 🎫 Issue #295.

### ▶ Changelist:

- added -mt-[1vh] to hero outer div

### 🎥 Screenshots & Screencasts:
<img width="1433" height="333" alt="Screenshot 2025-11-04 at 5 32 05 PM" src="https://github.com/user-attachments/assets/39cfd73f-e754-4f2b-a30d-c677241c7d68" />
