### PR TITLE
mainsite/bugfix/misc-cleanups

### DIFF
--- a/apps/main/src/app/(landing)/Sections/About.tsx
+++ b/apps/main/src/app/(landing)/Sections/About.tsx
@@ -12,7 +12,7 @@ import useDevice from "@util/hooks/useDevice";
 export default function About(): React.ReactNode {
   const { isMobile } = useDevice();
   return (
-    <div className="relative w-full my-10">
+    <div className="relative w-full my-10 overflow-hidden">
       <div className={`${isMobile ? "transform scale-[0.85]" : ""}`}>
         <RibbonTitle text="ABOUT US" />
       </div>

--- a/apps/main/src/app/(landing)/Sections/Apply.tsx
+++ b/apps/main/src/app/(landing)/Sections/Apply.tsx
@@ -7,9 +7,9 @@ import Button from "@repo/ui/Button";
 
 export default function Apply(): React.ReactNode {
   return (
-    <div className="flex flex-col justify-center items-center bg-canopyGreen h-[30vh] gap-2">
+    <div className="flex flex-col justify-center items-center bg-canopyGreen h-[30vh] gap-2 overflow-hidden">
       <h3 className="font-NeulisNeue-Bold text-center text-3xl text-black">
-        Applications open November 13th!
+        Applications are now live!
       </h3>
       <p className="font-DMSans-Regular text-charcoalFog mb-1">
         Apply by January 10th, 2026.

--- a/apps/main/src/app/(landing)/Sections/FAQ.tsx
+++ b/apps/main/src/app/(landing)/Sections/FAQ.tsx
@@ -76,7 +76,7 @@ const logisticsQuestions = [
       "HackBeanpot is a three day long event, beginning on Friday, February 11th and ending on Sunday, February 13th.",
   },
   {
-    question: "Will there be overnight acccommodations?",
+    question: "Will there be overnight accommodations?",
     answer:
       "HackBeanpot is a three day long event, beginning on Friday, February 11th and ending on Sunday, February 13th.",
   },

--- a/apps/main/src/app/(landing)/Sections/Keynote.tsx
+++ b/apps/main/src/app/(landing)/Sections/Keynote.tsx
@@ -19,7 +19,7 @@ export default function Keynote(): React.ReactNode {
 
   return (
     <div
-      className={`relative w-full ${
+      className={`relative w-full overflow-hidden ${
         isMobile
           ? "aspect-[1/1.6]"
           : isTablet
@@ -107,7 +107,7 @@ export default function Keynote(): React.ReactNode {
       </div>
 
       <KeynoteSpeakerForegroundWaves
-        className={`absolute w-[200vw] h-auto bottom-0`}
+        className={`absolute w-[200vw] h-auto bottom-0 overflow-hidden`}
       ></KeynoteSpeakerForegroundWaves>
     </div>
 

--- a/apps/main/src/app/(landing)/Sections/Landing.tsx
+++ b/apps/main/src/app/(landing)/Sections/Landing.tsx
@@ -18,14 +18,14 @@ export default function Landing(): React.ReactNode {
   const { isMobile, isTablet, isDesktop } = useDevice();
 
   return (
-    <div className="relative z-10">
+    <div className="relative z-10 overflow-hidden">
       <div
-        className={`relative w-full ${
+        className={`relative w-full overflow-hidden ${
           isMobile ? "aspect-[1]" : "aspect-[1.72/1]"
         }`}
       >
         <HeroLandingBackground
-          className="w-full h-auto"
+          className="w-full h-auto overflow-hidden"
           style={{
             transform: isMobile ? "scale(2.5)" : "scale(1)",
             transformOrigin: "top center",
@@ -34,7 +34,7 @@ export default function Landing(): React.ReactNode {
 
         {/* TODO: Remove if we are not MLH */}
         <MLHLogo
-          className={`absolute top-0 left-0  h-auto ${isMobile ? "w-[14vw]" : "w-[7vw]"}`}
+          className={`absolute top-0 left-0 h-auto ${isMobile ? "w-[14vw]" : "w-[7vw]"}`}
           style={{ transform: "translate(4vw, 0)" }}
         />
 
@@ -125,7 +125,7 @@ export default function Landing(): React.ReactNode {
         />
 
         <HeroLandingForeground
-          className={`absolute bottom-0 left-1/2 -translate-x-1/2 h-auto ${isMobile ? "w-[200vw]" : "w-[170vw]"}`}
+          className={`absolute bottom-0 left-1/2 -translate-x-1/2 h-auto ${isMobile ? "w-[200vw]" : "w-[170vw]" }`}
         />
       </div>
     </div>

--- a/apps/main/src/app/(landing)/Sections/Stats.tsx
+++ b/apps/main/src/app/(landing)/Sections/Stats.tsx
@@ -31,7 +31,7 @@ export default function Stats(): JSX.Element {
 
   return (
     <div
-      className="w-full bg-carouselCream flex justify-center"
+      className="w-full bg-carouselCream flex justify-center overflow-hidden"
       style={{ height: creamHeight }}
     >
       <div className="relative w-full h-full mx-auto">

--- a/apps/main/src/app/(landing)/Sections/Values.tsx
+++ b/apps/main/src/app/(landing)/Sections/Values.tsx
@@ -49,7 +49,7 @@ export default function Values() {
 
   return (
     <div
-      className={`relative w-full ${aspectRatio} bg-ribbonBlue overflow-visible`}
+      className={`relative w-full ${aspectRatio} bg-ribbonBlue overflow-hidden `}
     >
       {/* Foreground SVG Stuff (ballons, clouds, etc) */}
       <CloudsTop className="absolute z-30 top-0 left-1/2 w-[100vw] -mt-[13vw] h-auto -translate-x-1/2" />


### PR DESCRIPTION
# Bugfix - Misc. Cleanups

## 🎫 Issue #313 

## 🎨 Figma Link: https://www.figma.com/design/oqaBHJmfuH0Tf46TulyVV0/-Design--Mainsite?node-id=0-1&p=f&t=IUFjZAIrBsqr84SQ-0

### ▶ Changelist: 

- added overflow-hidden property to most divs 
- fixed typo in "acccomodations" in FAQ section
- fixed dates to 13-15
- changed application section to say "Applications are now live!" instead of Applications open November 13th

### 📝 Notes + 🚧 TODO:

- no longer any svgs showing when u zoom out of mainsite on mobile
- however, there is a bit of a green border on the right tho (not sure how to fix that) 
- (can see in ss attached below)

### 🧪 Testing:

- tested locally on desktop -> inspect looking at mobile iphone screen

### 🎥 Screenshots & Screencasts:
<img width="401" height="673" alt="Screenshot 2025-11-14 at 4 54 07 PM" src="https://github.com/user-attachments/assets/6526e649-9818-4caf-9b72-ba00192d26f7" />