### PR TITLE
NavBar Bugfixes

### DIFF
--- a/apps/live/src/app/(landing)/EventSchedule/index.tsx
+++ b/apps/live/src/app/(landing)/EventSchedule/index.tsx
@@ -11,7 +11,7 @@ import RibbonTitle from "@repo/ui/RibbonTitle";
 const EventSchedule = () => {
   const { isMobile } = useDevice();
   return (
-    <div className={`relative w-full bg-mossGreen`}>
+    <div className={`relative w-full bg-mossGreen`} id="schedule">
       {/* foreground */}
       <EventScheduleSquiggle
         className={`absolute z-20 top-0 w-full -mt-[15vh]`}

--- a/apps/live/src/app/(landing)/Judging/index.tsx
+++ b/apps/live/src/app/(landing)/Judging/index.tsx
@@ -15,7 +15,7 @@ export default function Judging(): React.ReactNode {
   const { isMobile } = useDevice();
 
   return (
-    <div className="relative w-full min-h-screen z-10 bg-mossGreen">
+    <div className="relative w-full min-h-screen z-10 bg-mossGreen" id="judging">
       <JudgingLiveBackground
         className={`absolute inset-0 w-full h-auto overflow-hidden`}
       />

--- a/apps/live/src/app/(landing)/OurTeam/index.tsx
+++ b/apps/live/src/app/(landing)/OurTeam/index.tsx
@@ -26,7 +26,7 @@ export default function OurTeam(): React.ReactNode {
   );
 
   return (
-    <div className="relative bg-mossGreenDark w-full h-full py-20">
+    <div className="relative bg-mossGreenDark w-full h-full py-20" id="team">
       <div className={innerStyles}>
         <div className={ribbonStyles}>
           <RibbonTitle text={"OUR TEAM"} />

--- a/packages/ui/src/KeynoteSpeakerSection.tsx
+++ b/packages/ui/src/KeynoteSpeakerSection.tsx
@@ -33,7 +33,7 @@ export default function KeynoteSpeakerSection({
   };
 
   return (
-    <div className="h-[190vh] mobile:h-[170vh] w-full bg-mossGreen">
+    <div className="h-[190vh] mobile:h-[170vh] w-full bg-mossGreen" id="keynote">
       <KeynoteTopSquiggle
         className="absolute z-10"
         style={{

--- a/packages/ui/src/NavBar/NavBarBase.tsx
+++ b/packages/ui/src/NavBar/NavBarBase.tsx
@@ -90,7 +90,7 @@ const NavBarBase: React.FC<NavBarProps> = ({
   );
 
   const navBarItemsStyles = clsx(
-    "flex gap-10 w-full items-center z-10 text-md",
+    "flex gap-10 w-full items-center z-10 text-md whitespace-nowrap",
     isDesktop
       ? "flex-row justify-end self-center p-4 text-lg"
       : "flex-col gap-8 bg-starlightBlue top-10 p-10",


### PR DESCRIPTION
# All links in NavBar are functional and text wrap was fixed

## 🎫 Issue #407 

## 🎨 [Figma Link](https://www.figma.com/design/b05Xhnr2DlQdxVJTZXB44J/-Design--Livesite?node-id=1-1937&p=f&t=OFdOq5ef6mYhssiQ-0)

### ▶ Changelist:
- All links in NavBar are functional now, including the judging section
- The text for the "Guest Speakers" NavBar item won't wrap on smaller desktop sizes now

### 🧪 Testing:
- Manual

### 🎥 Screenshots & Screencasts:

https://github.com/user-attachments/assets/745ab881-76bc-413f-8e7c-8c1a5533ba0b


