### PR TITLE
Added squiggle before sponsor section

### DIFF
--- a/apps/live/src/app/(landing)/Sponsors.tsx
+++ b/apps/live/src/app/(landing)/Sponsors.tsx
@@ -16,6 +16,8 @@ import CodeCraftersLogo from "@repo/ui/Logos/CodeCraftersLogo.svg";
 import appWizzyLogo from "@repo/ui/Logos/Appwizzy_logo.svg";
 import PureButton from "@repo/ui/Logos/PureButton.svg";
 
+import EventScheduleSquiggle from "../lib/Assets/SVG/EventSchedule/EventScheduleSquiggle.tsx";
+
 const LOGOS = {
   aws: AWSLogo,
   mavenAgi: MavenAGILogo,
@@ -83,13 +85,13 @@ export default function Sponsors(): JSX.Element {
   const innerStyles = clsx(
     "font-NeulisNeue-Regular flex flex-col items-center justify-center gap-12",
     isDesktop && "py-16 desktop:px-44 desktop-xl:px-80",
-    isTablet && "px-28",
+    isTablet && "px-28"
   );
 
   const ribbonStyles = clsx(
     isDesktop && "scale-100",
     isTablet && "scale-75",
-    isMobile && "scale-[60%]",
+    isMobile && "scale-[60%]"
   );
 
   const desktopRows = [
@@ -145,6 +147,7 @@ export default function Sponsors(): JSX.Element {
 
   return (
     <div className="relative bg-mossGreen w-full py-20" id="sponsors">
+      <EventScheduleSquiggle className={`absolute top-0 w-full -mt-[15vh]`} />
       <div className={innerStyles}>
         {/* Ribbon */}
         <div className={ribbonStyles}>


### PR DESCRIPTION
# Added transition squiggle before sponsor section

### ▶ Changelist:

- Took squiggle from eventSchedule and put it before sponsor section

### 📝 Notes + 🚧 TODO:

- might cut off a bit of our team section if browser size gets too small

### 🧪 Testing:

- local testing

### 🎥 Screenshots & Screencasts:
<img width="1046" height="425" alt="Screenshot 2026-02-10 at 4 30 28 PM" src="https://github.com/user-attachments/assets/83ec0c7c-f225-4879-bec8-1cfb29784f96" />