### PR TITLE
Updated keynote speaker event info, default our team, and our team blurb

### DIFF
--- a/apps/live/src/app/(landing)/OurTeam/OurTeamGrid.tsx
+++ b/apps/live/src/app/(landing)/OurTeam/OurTeamGrid.tsx
@@ -202,7 +202,7 @@ const TeamTable = () => {
     ],
   };
   type teamKey = keyof typeof teams;
-  const [currTeam, setCurrTeam] = useState<teamKey>("Tech");
+  const [currTeam, setCurrTeam] = useState<teamKey>("Directors");
 
   const changeTeam = (team: teamKey) => {
     setCurrTeam(team);

--- a/apps/live/src/app/(landing)/OurTeam/index.tsx
+++ b/apps/live/src/app/(landing)/OurTeam/index.tsx
@@ -37,7 +37,7 @@ export default function OurTeam(): React.ReactNode {
           </h1>
           <p className="font-DM-Sans-Regular">
             Feel free to reach out to a core member via Discord if you have any
-            questions or concerts about event logistics, applying to be part of
+            questions or concerns about event logistics, applying to be part of
             the HBP core team, or more!
           </p>
         </div>

--- a/packages/ui/src/KeynoteSpeakerSection.tsx
+++ b/packages/ui/src/KeynoteSpeakerSection.tsx
@@ -20,16 +20,16 @@ export default function KeynoteSpeakerSection({
     header: "Sue Harnett",
     bio: "CEO of Rewriting the Code",
     text: "Sue Harnett is the Founder & CEO of Rewriting the Code, the nonprofit she launched in 2017 that has grown into a global community of 38,000+ university and early-career women in tech, offering mentorship, education, and career-readiness programs. She will be speaking about women in technology, and the value of community, teamwork, and thoughtful leadership!",
-    location: "Zone A",
-    time: "Friday, 1pm",
+    location: "Boston Commons",
+    time: "Saturday, 10am",
   };
 
   const jessicaData = {
     header: "Jessica Cao",
     bio: "Stanford CS '26 / Founder of World37",
     text: "Jessica Cao is an undergraduate studying Computer Science at Stanford University, and the founder of World37, an AI-powered storytelling platform where players can engage with, create, and share their own unique stories. She will be speaking about the art of pitching a technical project!",
-    location: "Zone A",
-    time: "Friday, 1pm",
+    location: "Boston Commons",
+    time: "Saturday, 3:20pm",
   };
 
   return (


### PR DESCRIPTION
## 🎫 Issue #426

### ▶ Changelist:
- Fixed misspellings in Our Team blurb
- Fixed event date and time information in Keynote section
- Ensure our directors are the first to show up on Our Team:)

### 🧪 Testing:
- Manual

### 🎥 Screenshots & Screencasts:
<img width="1472" height="971" alt="image" src="https://github.com/user-attachments/assets/4390158a-7545-4f84-a9ac-3b87a0518752" />

<img width="1361" height="902" alt="image" src="https://github.com/user-attachments/assets/35ff174b-377e-4a42-9e32-8815cbcbdfc4" />

<img width="1617" height="793" alt="image" src="https://github.com/user-attachments/assets/8c3ae9ac-d619-46b8-9e0e-cbf084f3bb6a" />

