### PR TITLE
Mentor section styling changed

### DIFF
--- a/apps/live/src/app/(landing)/Mentors/MentorsTable.tsx
+++ b/apps/live/src/app/(landing)/Mentors/MentorsTable.tsx
@@ -14,20 +14,28 @@ type MentorTableProps = {
 };
 
 const MentorsTable = ({ data }: MentorTableProps) => {
-  const { isDesktop, isTablet, isMobile } = useDevice();
+  const { isDesktop, isMobile } = useDevice();
   const records = useMemo(() => data?.records ?? [], [data]);
   const [skillsFilter, setSkillsFilter] = useState<string[]>([]);
   const [availabilityFilter, setAvailabilityFilter] = useState<boolean>(false);
   const [dropdownOpen, setDropdownOpen] = useState<boolean>(false);
   const [selectedMentor, setSelectedMentor] = useState<MentorData | null>();
   const { setModal } = useContext(ModalContext);
-  const gridStyles = clsx(
-    "flex flex-wrap justify-center items-center mx-auto gap-6",
-    isDesktop && "w-3/4",
-    isMobile && "grid grid-cols-2",
-    isTablet && "grid grid-cols-3",
+
+  const outerDivStyles = clsx("w-screen overflow-hidden min-h-[50vh]",
+    isDesktop && "mb-20"
   );
 
+  const innerDivStyles = clsx(
+    "flex flex-row gap-4 font-GT-Walsheim-Regular py-4 items-center flex-wrap justify-center",
+    isMobile && "px-4",
+  );
+
+  const gridStyles = clsx(
+    "flex flex-wrap justify-center items-center mx-auto gap-6 pb-12",
+    isDesktop && "w-3/5",
+    isMobile && "grid grid-cols-2",
+  ); 
   const date = useMemo(() => new Date(), []);
 
   const uniqueSkills = useMemo(() => {
@@ -99,13 +107,10 @@ const MentorsTable = ({ data }: MentorTableProps) => {
 
   return (
     <div
-      className={`w-screen overflow-hidden min-h-[50vh] ${isDesktop ? "mb-20" : ""}`}
+      className={outerDivStyles}
     >
       <div
-        className={clsx(
-          "flex flex-row gap-4 font-GT-Walsheim-Regular py-4 items-center flex-wrap justify-center",
-          isMobile && "px-4",
-        )}
+        className={innerDivStyles}
       >
         <div className="relative inline-block text-left">
           <button
@@ -176,7 +181,7 @@ const MentorsTable = ({ data }: MentorTableProps) => {
         </button>
       </div>
 
-      <div className={clsx(gridStyles, "w-full pb-12")}>
+      <div className={gridStyles}>
         {(hasFilter ? filtered : records).map((record) => {
           const slots = record.fields["Time Slots"] || [];
           let isAvailable = false;

--- a/apps/live/src/app/(landing)/Mentors/index.tsx
+++ b/apps/live/src/app/(landing)/Mentors/index.tsx
@@ -73,6 +73,7 @@ const MentorSection = () => {
         </div>
         {/* Mentor listing (renders when Airtable data available) */}
         <MentorsTable data={data} />
+        
       </div>
     );
   });


### PR DESCRIPTION
# Mentor section styling changed

### ▶ Changelist:
- Updated mentor section styling to be more compact in desktop view 

### 🧪 Testing:
- Manual

### 🎥 Screenshots & Screencasts:
This is how the mentor section looked before on desktop:
<img width="2507" height="1041" alt="image" src="https://github.com/user-attachments/assets/29d705d0-7d80-4f21-9a1e-93d6502e3c54" />

This is how the mentor section looks now on desktop:
<img width="2508" height="1090" alt="image" src="https://github.com/user-attachments/assets/f6f063bf-5aa0-4eb7-b7a1-6c6ace2f21a9" />