### PR TITLE
Scaffolding for Admin Applicants Page

### DIFF
--- a/apps/app-portal/package.json
+++ b/apps/app-portal/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@repo/ui": "*",
+    "@tanstack/react-table": "^8.20.5",
     "@repo/util": "*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/app-portal/src/app/(admin)/admin/applicants/[id]/page.tsx
+++ b/apps/app-portal/src/app/(admin)/admin/applicants/[id]/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import React from "react";
+
+import { ApplicantDetail } from "@/components/admin/applicants/ApplicantDetail";
+import { DecisionEditor } from "@/components/admin/applicants/DecisionEditor";
+import { RsvpEditor } from "@/components/admin/applicants/RsvpEditor";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { getApplicant } from "@/lib/applicants/service";
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default async function ApplicantDetailPage({ params }: PageProps) {
+  const applicant = await getApplicant(params.id);
+  if (!applicant) notFound();
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <Link
+          href="/admin/applicants"
+          className="text-sm text-neutral-500 underline"
+        >
+          Back to applicants
+        </Link>
+      </div>
+
+      <ApplicantDetail applicant={applicant} />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Edit decision</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <DecisionEditor
+              applicantId={applicant.id}
+              value={applicant.decisionStatus}
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Edit RSVP</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RsvpEditor
+              applicantId={applicant.id}
+              value={applicant.rsvpStatus}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/app-portal/src/app/(admin)/admin/applicants/page.tsx
+++ b/apps/app-portal/src/app/(admin)/admin/applicants/page.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { ApplicantsFilters } from "@/components/admin/applicants/ApplicantsFilters";
+import { ApplicantsTable } from "@/components/admin/applicants/ApplicantsTable";
+import { ExportButtons } from "@/components/admin/applicants/ExportButtons";
+import { listApplicants } from "@/lib/applicants/service";
+
+export default async function ApplicantsPage() {
+  const { rows, total } = await listApplicants();
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Applicants</h1>
+          <p className="text-sm text-neutral-500">{total} total</p>
+        </div>
+        <ExportButtons />
+      </header>
+      <ApplicantsFilters />
+      <ApplicantsTable rows={rows} />
+    </div>
+  );
+}

--- a/apps/app-portal/src/app/api/v1/applicants/[id]/route.ts
+++ b/apps/app-portal/src/app/api/v1/applicants/[id]/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { getApplicant } from "@/lib/applicants/service";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const applicant = await getApplicant(params.id);
+  if (!applicant) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json(applicant);
+}
+
+export async function POST() {
+  return NextResponse.json({ error: "Not implemented" }, { status: 501 });
+}

--- a/apps/app-portal/src/app/api/v1/applicants/route.ts
+++ b/apps/app-portal/src/app/api/v1/applicants/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+
+import { listApplicants } from "@/lib/applicants/service";
+
+export async function GET() {
+  const result = await listApplicants();
+  return NextResponse.json(result);
+}

--- a/apps/app-portal/src/app/api/v1/export/applications/route.ts
+++ b/apps/app-portal/src/app/api/v1/export/applications/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return new NextResponse("Not implemented", { status: 501 });
+}

--- a/apps/app-portal/src/app/api/v1/export/post-acceptance/route.ts
+++ b/apps/app-portal/src/app/api/v1/export/post-acceptance/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return new NextResponse("Not implemented", { status: 501 });
+}

--- a/apps/app-portal/src/components/admin/applicants/ApplicantDetail.tsx
+++ b/apps/app-portal/src/components/admin/applicants/ApplicantDetail.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ApplicantDetail as ApplicantDetailType } from "@/lib/applicants/types";
+
+interface ApplicantDetailProps {
+  applicant: ApplicantDetailType;
+}
+
+function ResponseList({ responses }: { responses?: Record<string, unknown> }) {
+  if (!responses || Object.keys(responses).length === 0) {
+    return <p className="text-sm text-neutral-500">No responses recorded.</p>;
+  }
+  return (
+    <dl className="grid grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2">
+      {Object.entries(responses).map(([k, v]) => (
+        <div key={k} className="border-b border-neutral-100 py-2">
+          <dt className="text-xs font-medium uppercase text-neutral-500">
+            {k}
+          </dt>
+          <dd className="text-sm">
+            {Array.isArray(v) ? v.join(", ") : String(v ?? "—")}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+export function ApplicantDetail({ applicant }: ApplicantDetailProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>{applicant.email}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-4">
+            <div>
+              <dt className="text-xs text-neutral-500">Application</dt>
+              <dd>{applicant.applicationStatus}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-neutral-500">Decision</dt>
+              <dd>{applicant.decisionStatus ?? "—"}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-neutral-500">RSVP</dt>
+              <dd>{applicant.rsvpStatus}</dd>
+            </div>
+            <div>
+              <dt className="text-xs text-neutral-500">Submitted</dt>
+              <dd>
+                {applicant.appSubmissionTime
+                  ? new Date(applicant.appSubmissionTime).toLocaleString()
+                  : "—"}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Application responses</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponseList responses={applicant.applicationResponses} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Post-acceptance responses</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponseList responses={applicant.postAcceptanceResponses} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/app-portal/src/components/admin/applicants/ApplicantsFilters.tsx
+++ b/apps/app-portal/src/components/admin/applicants/ApplicantsFilters.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import React from "react";
+
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { APPLICATION_STATUSES, DECISION_STATUSES } from "@/lib/types/user";
+
+export function ApplicantsFilters() {
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      <Input placeholder="Search" className="max-w-xs" />
+      <Select>
+        <SelectTrigger className="w-48">
+          <SelectValue placeholder="Status" />
+        </SelectTrigger>
+        <SelectContent>
+          {APPLICATION_STATUSES.map((s) => (
+            <SelectItem key={s} value={s}>
+              {s}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Select>
+        <SelectTrigger className="w-48">
+          <SelectValue placeholder="Decision" />
+        </SelectTrigger>
+        <SelectContent>
+          {DECISION_STATUSES.map((s) => (
+            <SelectItem key={s} value={s}>
+              {s}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/app-portal/src/components/admin/applicants/ApplicantsTable.tsx
+++ b/apps/app-portal/src/components/admin/applicants/ApplicantsTable.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import Link from "next/link";
+import React, { useState } from "react";
+import {
+  ColumnDef,
+  SortingState,
+  flexRender,
+  getCoreRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { ArrowUpDown } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { ApplicantSummary } from "@/lib/applicants/types";
+
+interface ApplicantsTableProps {
+  rows: ApplicantSummary[];
+}
+
+const columns: ColumnDef<ApplicantSummary>[] = [
+  {
+    accessorKey: "email",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Email <ArrowUpDown className="ml-2 h-3 w-3" />
+      </Button>
+    ),
+  },
+  { accessorKey: "applicationStatus", header: "Application" },
+  {
+    accessorKey: "decisionStatus",
+    header: "Decision",
+    cell: ({ row }) => row.original.decisionStatus ?? "—",
+  },
+  { accessorKey: "rsvpStatus", header: "RSVP" },
+  {
+    accessorKey: "appSubmissionTime",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Submitted <ArrowUpDown className="ml-2 h-3 w-3" />
+      </Button>
+    ),
+    cell: ({ row }) =>
+      row.original.appSubmissionTime
+        ? new Date(row.original.appSubmissionTime).toLocaleDateString()
+        : "—",
+  },
+  {
+    id: "actions",
+    header: "",
+    cell: ({ row }) => (
+      <Link
+        href={`/admin/applicants/${row.original.id}`}
+        className="text-sm font-medium underline"
+      >
+        View
+      </Link>
+    ),
+  },
+];
+
+export function ApplicantsTable({ rows }: ApplicantsTableProps) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: 25 } },
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((hg) => (
+              <TableRow key={hg.id}>
+                {hg.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="text-center text-neutral-500"
+                >
+                  No applicants
+                </TableCell>
+              </TableRow>
+            ) : (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.previousPage()}
+          disabled={!table.getCanPreviousPage()}
+        >
+          Previous
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => table.nextPage()}
+          disabled={!table.getCanNextPage()}
+        >
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/app-portal/src/components/admin/applicants/DecisionEditor.tsx
+++ b/apps/app-portal/src/components/admin/applicants/DecisionEditor.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import type { DecisionStatus } from "@/lib/types/user";
+
+interface DecisionEditorProps {
+  applicantId: string;
+  value?: DecisionStatus;
+}
+
+export function DecisionEditor({ applicantId, value }: DecisionEditorProps) {
+  return (
+    <div className="flex items-end gap-2">
+      <div className="flex-1 text-sm">
+        <span className="mb-1 block text-xs font-medium text-neutral-600">
+          Decision
+        </span>
+        <span>{value ?? "—"}</span>
+      </div>
+      <Button
+        onClick={() =>
+          toast.message(`Not implemented: edit decision for ${applicantId}`)
+        }
+      >
+        Edit
+      </Button>
+    </div>
+  );
+}

--- a/apps/app-portal/src/components/admin/applicants/ExportButtons.tsx
+++ b/apps/app-portal/src/components/admin/applicants/ExportButtons.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import React from "react";
+
+import { Button } from "@/components/ui/button";
+
+export function ExportButtons() {
+  return (
+    <div className="flex gap-2">
+      <Button variant="outline" asChild>
+        <a href="/api/v1/export/applications">Export applications CSV</a>
+      </Button>
+      <Button variant="outline" asChild>
+        <a href="/api/v1/export/post-acceptance">Export RSVPs CSV</a>
+      </Button>
+    </div>
+  );
+}

--- a/apps/app-portal/src/components/admin/applicants/RsvpEditor.tsx
+++ b/apps/app-portal/src/components/admin/applicants/RsvpEditor.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import type { RsvpStatus } from "@/lib/types/user";
+
+interface RsvpEditorProps {
+  applicantId: string;
+  value: RsvpStatus;
+}
+
+export function RsvpEditor({ applicantId, value }: RsvpEditorProps) {
+  return (
+    <div className="flex items-end gap-2">
+      <div className="flex-1 text-sm">
+        <span className="mb-1 block text-xs font-medium text-neutral-600">
+          RSVP
+        </span>
+        <span>{value}</span>
+      </div>
+      <Button
+        onClick={() =>
+          toast.message(`Not implemented: edit RSVP for ${applicantId}`)
+        }
+      >
+        Edit
+      </Button>
+    </div>
+  );
+}

--- a/apps/app-portal/src/lib/applicants/csv.ts
+++ b/apps/app-portal/src/lib/applicants/csv.ts
@@ -1,0 +1,11 @@
+export interface CsvColumn<T> {
+  key: string;
+  header: string;
+  value: (row: T) => string | number | boolean | null | undefined;
+}
+
+export function toCsv<T>(rows: T[], columns: CsvColumn<T>[]): string {
+  throw new Error(
+    `Not implemented: toCsv(${rows.length} rows, ${columns.length} cols)`,
+  );
+}

--- a/apps/app-portal/src/lib/applicants/queries.ts
+++ b/apps/app-portal/src/lib/applicants/queries.ts
@@ -1,0 +1,13 @@
+import type { Filter } from "mongodb";
+import type { ApplicantFilters } from "./types";
+
+export function buildApplicantQuery(
+  filters: ApplicantFilters,
+): Filter<Record<string, unknown>> {
+  const query: Filter<Record<string, unknown>> = {};
+  if (filters.search) query.email = { $regex: filters.search, $options: "i" };
+  if (filters.applicationStatus)
+    query.applicationStatus = filters.applicationStatus;
+  if (filters.decisionStatus) query.decisionStatus = filters.decisionStatus;
+  return query;
+}

--- a/apps/app-portal/src/lib/applicants/service.ts
+++ b/apps/app-portal/src/lib/applicants/service.ts
@@ -1,0 +1,121 @@
+import type {
+  ApplicantDetail,
+  ApplicantListResult,
+  ApplicantSummary,
+  ApplicantUpdate,
+} from "./types";
+
+const MOCK_APPLICANTS: ApplicantDetail[] = [
+  {
+    id: "mock-001",
+    email: "ada.lovelace@example.com",
+    applicationStatus: "submitted",
+    decisionStatus: "admitted",
+    rsvpStatus: "confirmed",
+    appSubmissionTime: "2026-02-12T14:03:00.000Z",
+    rsvpSubmissionTime: "2026-03-01T18:22:00.000Z",
+    applicationResponses: {
+      firstName: "Ada",
+      lastName: "Lovelace",
+      school: "Northeastern University",
+      year: "Junior",
+      whyHackBeanPot: "I want to build a punch-card-driven web app.",
+    },
+    postAcceptanceResponses: {
+      dietaryRestrictions: "Vegetarian",
+      tshirtSize: "M",
+    },
+  },
+  {
+    id: "mock-002",
+    email: "grace.hopper@example.com",
+    applicationStatus: "submitted",
+    decisionStatus: "admitted",
+    rsvpStatus: "not-attending",
+    appSubmissionTime: "2026-02-10T09:45:00.000Z",
+    rsvpSubmissionTime: "2026-03-02T12:00:00.000Z",
+    applicationResponses: {
+      firstName: "Grace",
+      lastName: "Hopper",
+      school: "Yale",
+      year: "Senior",
+      whyHackBeanPot: "Compilers are cool.",
+    },
+  },
+  {
+    id: "mock-003",
+    email: "alan.turing@example.com",
+    applicationStatus: "submitted",
+    decisionStatus: "waitlisted",
+    rsvpStatus: "unconfirmed",
+    appSubmissionTime: "2026-02-14T22:10:00.000Z",
+  },
+  {
+    id: "mock-004",
+    email: "linus.torvalds@example.com",
+    applicationStatus: "submitted",
+    decisionStatus: "declined",
+    rsvpStatus: "unconfirmed",
+    appSubmissionTime: "2026-02-13T16:30:00.000Z",
+  },
+  {
+    id: "mock-005",
+    email: "margaret.hamilton@example.com",
+    applicationStatus: "submitted",
+    decisionStatus: "pending",
+    rsvpStatus: "unconfirmed",
+    appSubmissionTime: "2026-02-15T11:15:00.000Z",
+  },
+  {
+    id: "mock-006",
+    email: "katherine.johnson@example.com",
+    applicationStatus: "incomplete",
+    rsvpStatus: "unconfirmed",
+  },
+  {
+    id: "mock-007",
+    email: "dennis.ritchie@example.com",
+    applicationStatus: "not-started",
+    rsvpStatus: "unconfirmed",
+  },
+  {
+    id: "mock-008",
+    email: "barbara.liskov@example.com",
+    applicationStatus: "submitted",
+    decisionStatus: "admitted",
+    rsvpStatus: "confirmed",
+    appSubmissionTime: "2026-02-11T08:00:00.000Z",
+    rsvpSubmissionTime: "2026-03-03T09:30:00.000Z",
+  },
+];
+
+function toSummary(detail: ApplicantDetail): ApplicantSummary {
+  return {
+    id: detail.id,
+    email: detail.email,
+    applicationStatus: detail.applicationStatus,
+    decisionStatus: detail.decisionStatus,
+    rsvpStatus: detail.rsvpStatus,
+    appSubmissionTime: detail.appSubmissionTime,
+  };
+}
+
+export async function listApplicants(): Promise<ApplicantListResult> {
+  const rows = MOCK_APPLICANTS.map(toSummary);
+  return { rows, total: rows.length, page: 1, pageSize: rows.length };
+}
+
+export async function getApplicant(
+  id: string,
+): Promise<ApplicantDetail | null> {
+  return MOCK_APPLICANTS.find((a) => a.id === id) ?? null;
+}
+
+export async function updateApplicant(
+  id: string,
+  update: ApplicantUpdate,
+): Promise<ApplicantDetail> {
+  throw new Error(
+    `Not implemented: updateApplicant(${id}, ${JSON.stringify(update)})`,
+  );
+}

--- a/apps/app-portal/src/lib/applicants/types.ts
+++ b/apps/app-portal/src/lib/applicants/types.ts
@@ -1,0 +1,42 @@
+import type {
+  ApplicationStatus,
+  DecisionStatus,
+  RsvpStatus,
+} from "@/lib/types/user";
+import type {
+  ApplicationResponse,
+  PostAcceptanceResponse,
+} from "@/lib/types/application";
+
+export interface ApplicantSummary {
+  id: string;
+  email: string;
+  applicationStatus: ApplicationStatus;
+  decisionStatus?: DecisionStatus;
+  rsvpStatus: RsvpStatus;
+  appSubmissionTime?: string;
+}
+
+export interface ApplicantDetail extends ApplicantSummary {
+  applicationResponses?: ApplicationResponse;
+  postAcceptanceResponses?: PostAcceptanceResponse;
+  rsvpSubmissionTime?: string;
+}
+
+export interface ApplicantFilters {
+  search?: string;
+  applicationStatus?: ApplicationStatus;
+  decisionStatus?: DecisionStatus;
+}
+
+export interface ApplicantUpdate {
+  decisionStatus?: DecisionStatus;
+  rsvpStatus?: RsvpStatus;
+}
+
+export interface ApplicantListResult {
+  rows: ApplicantSummary[];
+  total: number;
+  page: number;
+  pageSize: number;
+}

--- a/apps/app-portal/src/lib/types/user.ts
+++ b/apps/app-portal/src/lib/types/user.ts
@@ -1,8 +1,23 @@
-export type ApplicationStatus = "not-started" | "incomplete" | "submitted";
+export const APPLICATION_STATUSES = [
+  "not-started",
+  "incomplete",
+  "submitted",
+] as const;
+export const DECISION_STATUSES = [
+  "pending",
+  "admitted",
+  "waitlisted",
+  "declined",
+] as const;
+export const RSVP_STATUSES = [
+  "unconfirmed",
+  "confirmed",
+  "not-attending",
+] as const;
 
-export type DecisionStatus = "pending" | "admitted" | "waitlisted" | "declined";
-
-export type RsvpStatus = "unconfirmed" | "confirmed" | "not-attending";
+export type ApplicationStatus = (typeof APPLICATION_STATUSES)[number];
+export type DecisionStatus = (typeof DECISION_STATUSES)[number];
+export type RsvpStatus = (typeof RSVP_STATUSES)[number];
 
 export interface PortalUser {
   email: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -774,6 +774,18 @@
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
 
+"@tanstack/react-table@^8.20.5":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.21.3.tgz#2c38c747a5731c1a07174fda764b9c2b1fb5e91b"
+  integrity sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==
+  dependencies:
+    "@tanstack/table-core" "8.21.3"
+
+"@tanstack/table-core@8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
+  integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
+
 "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"


### PR DESCRIPTION
# Scaffolding for Admin Applicants Page

## 🎫 Issue #454 .

### ▶ Changelist:

- Adds scaffolding for the applicants table and detail pages, as well as backend routes
- Creates mock data
- Changes `lib/types/user.ts` slightly to allow iterating over the enum. (for drop downs)

### 🧪 Testing:

- Pages should be viewable with mock data at `http://localhost:3000/admin/applicants`

### 🎥 Screenshots & Screencasts:

### Applicants Main Page
<img width="2522" height="967" alt="image" src="https://github.com/user-attachments/assets/3f358bba-7e6f-43bf-a1a9-e1eefc9ad73d" />

### Applicants Detail Page
<img width="2527" height="1250" alt="image" src="https://github.com/user-attachments/assets/575f9e1a-3633-4b25-ba1f-4fda2ed051b3" />
