### PR TITLE
Config Changes to Fix Line Ending Churn

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-* text=auto
-*.tsx text eol=lf
+* text=auto eol=lf

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "lf"
+}


### PR DESCRIPTION
# Config Changes to Fix Prettier Messing With Line Endings on Windows

### ▶ Changelist:

- Changes the git config so that it gives all files LF (Mac / Linux) line endings on all platforms. Previously only .tsx files got this treatement
- Adds a config for prettier to ensure it stays in sync with this, and always expects LF line endings

### 📝 Notes + 🚧 TODO:

- I've done a little bit of research and it seems like this is a common approach for this type of issue. The only thing we need to keep in mind is adding an exception to the config if we ever use any windows specific files, like .ps1 files.
