### PR TITLE
Change App Portal Tailwind Config

### DIFF
--- a/apps/app-portal/tailwind.config.ts
+++ b/apps/app-portal/tailwind.config.ts
@@ -1,11 +1,19 @@
 // tailwind config is required for editor support
 
 import type { Config } from "tailwindcss";
+import defaultColors from "tailwindcss/colors";
 import sharedConfig from "@repo/tailwind-config";
+import { colors as projectColors } from "@repo/tailwind-config/tokens";
 
-const config: Pick<Config, "content" | "presets"> = {
+const config: Pick<Config, "content" | "presets" | "theme"> = {
   content: ["./src/app/**/*.tsx", "./src/components/**/*.tsx"],
   presets: [sharedConfig],
+  theme: {
+    colors: {
+      ...defaultColors,
+      ...projectColors,
+    },
+  },
 };
 
 export default config;


### PR DESCRIPTION
# Changes the app-portal tailwind config to include the default tailwind colors

### ▶ Changelist:

- Changes the tailwind config to include the default tailwind colors used in the shadcn components we have been making use of in our app portal prs. Previously the tailwind in app-portal was inheriting the project wide tailwind config "theme" attribute, meaning it only had access to our custom color scheme (`projectColors` in the config).

### 🧪 Testing:

- All shadcn components should no longer look off/ broken. The filtering dropdowns in my Applicants table page PR are a good example, as is the on-hover effect on the table rows 
(#474)

### 🎥 Screenshots & Screencasts:

**Before**

<img width="2247" height="998" alt="image" src="https://github.com/user-attachments/assets/ca0cb930-283c-440e-be22-9bd0b64479ed" />

---

**After**

<img width="2302" height="1034" alt="image" src="https://github.com/user-attachments/assets/2e71ac08-8007-4a51-b218-551120498c87" />
