### PR TITLE
Admin Stats Dashboard - read endpoint with all aggregations

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
-if pgrep -f "next dev" >/dev/null; then
+if command -v pgrep >/dev/null 2>&1 && pgrep -f "next dev" >/dev/null; then
   echo "A Next.js dev server is running. Stop it before committing (it conflicts with the build)."
   exit 1
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,8 @@
+if pgrep -f "next dev" >/dev/null; then
+  echo "A Next.js dev server is running. Stop it before committing (it conflicts with the build)."
+  exit 1
+fi
+
 yarn build
 yarn format
 yarn lint

--- a/apps/app-portal/jest.config.ts
+++ b/apps/app-portal/jest.config.ts
@@ -4,6 +4,7 @@ const config: Config = {
   preset: "ts-jest",
   testEnvironment: "node",
   moduleNameMapper: {
+    "^@/lib/db$": "<rootDir>/src/lib/db.stub.ts",
     "^@/(.*)$": "<rootDir>/src/$1",
   },
 };

--- a/apps/app-portal/package.json
+++ b/apps/app-portal/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "seed": "node --env-file=.env --import tsx scripts/seed.ts",
-    "setup-indexes": "node --env-file=.env --import tsx scripts/setup-indexes.ts"
+    "setup-indexes": "node --env-file=.env --import tsx scripts/setup-indexes.ts",
+    "test": "jest"
   },
   "dependencies": {
     "@google-cloud/storage": "^7.21.0",
@@ -49,11 +50,16 @@
     "@repo/eslint-config": "*",
     "@repo/tailwind-config": "*",
     "@repo/typescript-config": "*",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20.11.24",
     "@types/nodemailer": "^8.0.1",
     "@types/react": "^18.2.61",
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10.4.18",
+    "jest": "^29.7.0",
+    "mongodb-memory-server": "^10.1.2",
+    "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
     "eslint-config-next": "15.0.3",
     "postcss": "^8.4.35",

--- a/apps/app-portal/src/app/(admin)/admin/stats/page.tsx
+++ b/apps/app-portal/src/app/(admin)/admin/stats/page.tsx
@@ -8,6 +8,6 @@ export const dynamic = "force-dynamic"; // render on every request
 export default async function StatsPage(): Promise<JSX.Element> {
   const payload = await getStats();
   return (
-    <StatsDashboard payload={payload} generatedAt={new Date().toISOString()} />
+    <StatsDashboard payload={payload} generatedAt={payload.generatedAt} />
   );
 }

--- a/apps/app-portal/src/app/(admin)/admin/stats/page.tsx
+++ b/apps/app-portal/src/app/(admin)/admin/stats/page.tsx
@@ -7,7 +7,5 @@ export const dynamic = "force-dynamic"; // render on every request
 
 export default async function StatsPage(): Promise<JSX.Element> {
   const payload = await getStats();
-  return (
-    <StatsDashboard payload={payload} generatedAt={payload.generatedAt} />
-  );
+  return <StatsDashboard payload={payload} generatedAt={payload.generatedAt} />;
 }

--- a/apps/app-portal/src/app/api/v1/stats/route.ts
+++ b/apps/app-portal/src/app/api/v1/stats/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 
 import { getStats } from "@/lib/stats/service";
 
+export const dynamic = "force-dynamic";
+
 // GET aggregate stats
 // TODO: gate with requireAdmin() once Ticket 1 ships its helpers.
 export async function GET() {

--- a/apps/app-portal/src/app/api/v1/stats/route.ts
+++ b/apps/app-portal/src/app/api/v1/stats/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { getStats } from "@/lib/stats/service";
 
 // GET aggregate stats
+// TODO: gate with requireAdmin() once Ticket 1 ships its helpers.
 export async function GET() {
   try {
     const payload = await getStats();

--- a/apps/app-portal/src/components/admin/stats/DemographicsChart.tsx
+++ b/apps/app-portal/src/components/admin/stats/DemographicsChart.tsx
@@ -33,10 +33,19 @@ interface DemographicsChartProps {
   dimension?: DemographicsDimension;
 }
 
-// turns a snake_case dimension key into a readable label
+const DIMENSION_LABELS: Record<DemographicsDimension, string> = {
+  school: "School",
+  yearOfEducation: "Year of Education",
+  majors: "Majors",
+  gender: "Gender",
+  races: "Races",
+  shirtSize: "Shirt Size",
+  hackathonsAttended: "Hackathons Attended",
+  csClassesTaken: "CS Classes Taken",
+};
+
 function formatDimension(key: DemographicsDimension): string {
-  const spaced = key.replace(/_/g, " ");
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+  return DIMENSION_LABELS[key];
 }
 
 const config: ChartConfig = {
@@ -48,13 +57,12 @@ const config: ChartConfig = {
 
 const EMPTY_MESSAGE = "No data yet";
 
-// splits a long label into two balanced lines on a word boundary
-function splitLabel(label: string): [string, string?] {
-  const words = label.split(" ");
-  if (words.length < 2) return [label];
+const MAX_LABEL_LENGTH = 14;
 
-  const mid = Math.ceil(words.length / 2);
-  return [words.slice(0, mid).join(" "), words.slice(mid).join(" ")];
+// truncates a long label with an ellipsis so rotated ticks don't overlap
+function truncateLabel(label: string): string {
+  if (label.length <= MAX_LABEL_LENGTH) return label;
+  return `${label.slice(0, MAX_LABEL_LENGTH - 1)}…`;
 }
 
 export function DemographicsChart({
@@ -93,7 +101,7 @@ export function DemographicsChart({
             <BarChart
               data={entries}
               barCategoryGap={8}
-              margin={{ left: 0, right: 8, top: 8, bottom: 0 }}
+              margin={{ left: 8, right: 24, top: 8, bottom: 16 }}
             >
               <CartesianGrid vertical={false} strokeDasharray="3 3" />
               <XAxis
@@ -101,30 +109,21 @@ export function DemographicsChart({
                 tickLine={false}
                 axisLine={false}
                 interval={0}
-                height={48}
+                height={72}
                 tickMargin={8}
-                tick={({ x, y, payload }) => {
-                  const [line1, line2] = splitLabel(
-                    String(payload.value ?? ""),
-                  );
-                  return (
-                    <text
-                      x={x}
-                      y={y}
-                      dy={12}
-                      textAnchor="middle"
-                      fontSize={12}
-                      fill="currentColor"
-                    >
-                      <tspan x={x}>{line1}</tspan>
-                      {line2 ? (
-                        <tspan x={x} dy={14}>
-                          {line2}
-                        </tspan>
-                      ) : null}
-                    </text>
-                  );
-                }}
+                tick={({ x, y, payload }) => (
+                  <text
+                    x={x}
+                    y={y}
+                    dy={8}
+                    textAnchor="end"
+                    fontSize={12}
+                    fill="currentColor"
+                    transform={`rotate(-35, ${x}, ${y})`}
+                  >
+                    {truncateLabel(String(payload.value ?? ""))}
+                  </text>
+                )}
               />
               <YAxis tickLine={false} axisLine={false} width={32} />
               <ChartTooltip

--- a/apps/app-portal/src/components/admin/stats/StatCard.tsx
+++ b/apps/app-portal/src/components/admin/stats/StatCard.tsx
@@ -17,7 +17,7 @@ export function StatCard({ metric }: StatCardProps): JSX.Element {
 
   return (
     <Card>
-      <CardContent className="pt-6">
+      <CardContent className="!pt-10">
         {value === null ? (
           <span className="text-3xl font-semibold tracking-tight text-heather">
             —

--- a/apps/app-portal/src/components/admin/stats/StatCard.tsx
+++ b/apps/app-portal/src/components/admin/stats/StatCard.tsx
@@ -17,7 +17,7 @@ export function StatCard({ metric }: StatCardProps): JSX.Element {
 
   return (
     <Card>
-      <CardContent className="!pt-10">
+      <CardContent className="!pt-4">
         {value === null ? (
           <span className="text-3xl font-semibold tracking-tight text-heather">
             —

--- a/apps/app-portal/src/components/admin/stats/StatsDashboard.tsx
+++ b/apps/app-portal/src/components/admin/stats/StatsDashboard.tsx
@@ -33,7 +33,21 @@ export function StatsDashboard({
       </section>
 
       <section className="grid grid-cols-2 gap-4 mobile:grid-cols-1 mobile-xl:grid-cols-1">
-        <StatusBreakdownChart breakdown={payload.statusBreakdown} />
+        <StatusBreakdownChart
+          entries={payload.statusBreakdown}
+          title="Applications by Status"
+          emptyMessage="No applications yet"
+        />
+        <StatusBreakdownChart
+          entries={payload.decisionBreakdown}
+          title="Decisions by Status"
+          emptyMessage="No decisions yet"
+        />
+        <StatusBreakdownChart
+          entries={payload.rsvpBreakdown}
+          title="RSVPs by Status"
+          emptyMessage="No RSVPs yet"
+        />
         <DemographicsChart breakdown={payload.demographics} />
         <div className="col-span-2">
           <SubmissionTimeline timeline={payload.timeline} />

--- a/apps/app-portal/src/components/admin/stats/StatusBreakdownChart.tsx
+++ b/apps/app-portal/src/components/admin/stats/StatusBreakdownChart.tsx
@@ -12,27 +12,16 @@ import {
   ChartTooltipContent,
   type ChartConfig,
 } from "@/components/ui/chart";
-import type { StatusBreakdown, StatusKind } from "@/lib/stats/types";
+import type { BreakdownEntry } from "@/lib/stats/types";
 
 import { ChartEmpty } from "./ChartEmpty";
 import { TooltipRow } from "./TooltipRow";
 
 interface StatusBreakdownChartProps {
-  breakdown: StatusBreakdown;
-  kind?: StatusKind;
+  entries: BreakdownEntry[];
+  title: string;
+  emptyMessage: string;
 }
-
-const TITLES: Record<StatusKind, string> = {
-  application: "Applications by Status",
-  decision: "Decisions by Status",
-  rsvp: "RSVPs by Status",
-};
-
-const EMPTY_MESSAGES: Record<StatusKind, string> = {
-  application: "No applications yet",
-  decision: "No decisions yet",
-  rsvp: "No RSVPs yet",
-};
 
 // colors assigned positionally from brand palette
 const PALETTE = [
@@ -46,10 +35,10 @@ const PALETTE = [
 ];
 
 export function StatusBreakdownChart({
-  breakdown,
-  kind = "application",
+  entries,
+  title,
+  emptyMessage,
 }: StatusBreakdownChartProps): JSX.Element {
-  const entries = breakdown[kind];
   const total = entries.reduce((sum, e) => sum + e.count, 0);
 
   const rows = entries.map((e, i) => ({
@@ -67,11 +56,11 @@ export function StatusBreakdownChart({
   return (
     <Card>
       <CardHeader>
-        <CardTitle>{TITLES[kind]}</CardTitle>
+        <CardTitle>{title}</CardTitle>
       </CardHeader>
       <CardContent>
         {total === 0 ? (
-          <ChartEmpty message={EMPTY_MESSAGES[kind]} />
+          <ChartEmpty message={emptyMessage} />
         ) : (
           <div className="flex flex-col items-center gap-6 sm:flex-row sm:justify-center">
             <ChartContainer

--- a/apps/app-portal/src/components/admin/stats/SubmissionTimeline.tsx
+++ b/apps/app-portal/src/components/admin/stats/SubmissionTimeline.tsx
@@ -22,7 +22,7 @@ interface SubmissionTimelineProps {
 }
 
 const config: ChartConfig = {
-  submissions: {
+  count: {
     label: "Submissions",
     color: colors.green,
   },
@@ -72,8 +72,8 @@ export function SubmissionTimeline({
                 }
               />
               <Line
-                dataKey="submissions"
-                stroke="var(--color-submissions)"
+                dataKey="count"
+                stroke="var(--color-count)"
                 strokeWidth={2}
                 dot={{ r: 3 }}
                 activeDot={{ r: 5 }}

--- a/apps/app-portal/src/components/admin/stats/SubmissionTimeline.tsx
+++ b/apps/app-portal/src/components/admin/stats/SubmissionTimeline.tsx
@@ -30,6 +30,12 @@ const config: ChartConfig = {
 
 const EMPTY_MESSAGE = "No submissions yet";
 
+// formats an ISO date string (yyyy-mm-dd) as mm-dd-yy
+function formatDateTooltip(date: string): string {
+  const [year, month, day] = date.split("-");
+  return `${month}-${day}-${year.slice(2)}`;
+}
+
 export function SubmissionTimeline({
   timeline,
 }: SubmissionTimelineProps): JSX.Element {
@@ -62,6 +68,7 @@ export function SubmissionTimeline({
               <ChartTooltip
                 content={
                   <ChartTooltipContent
+                    labelFormatter={(label) => formatDateTooltip(String(label))}
                     formatter={(value, name) => (
                       <TooltipRow
                         label={config[name as string]?.label ?? name}

--- a/apps/app-portal/src/lib/db.stub.ts
+++ b/apps/app-portal/src/lib/db.stub.ts
@@ -1,0 +1,13 @@
+// Test-only stand-in for "@/lib/db". The real module opens a live Mongo
+// connection at import time, which crashes Jest after tests finish. Tests
+// that need a real database use their own mongodb-memory-server instance and
+// only need resolveCollectionName's naming behavior from this module.
+export function resolveCollectionName(baseName: string): string {
+  return `${baseName}_test`;
+}
+
+export async function getDb(): Promise<never> {
+  throw new Error(
+    "getDb() is not available in tests; pass a Db instance directly.",
+  );
+}

--- a/apps/app-portal/src/lib/stats/aggregations.test.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.test.ts
@@ -15,59 +15,61 @@ import {
 // "_test" suffixed collection name.
 const COLLECTION_NAME = "applicant_data_test";
 
+// Status casing mirrors production applicant_data (uppercase-first;
+// rsvp "Not Attending" is space-separated, not hyphenated).
 const APPLICANTS = [
   // 1: not-started, no decision/rsvp, no submission
   { applicationStatus: "not-started" },
   // 2
   {
-    applicationStatus: "submitted",
-    decisionStatus: "admitted",
-    rsvpStatus: "confirmed",
+    applicationStatus: "Submitted",
+    decisionStatus: "Admitted",
+    rsvpStatus: "Confirmed",
     appSubmissionTime: "2024-01-01T00:00:00.000Z",
     applicationResponses: { school: "NEU" },
   },
   // 3
   {
-    applicationStatus: "submitted",
-    decisionStatus: "admitted",
-    rsvpStatus: "confirmed",
+    applicationStatus: "Submitted",
+    decisionStatus: "Admitted",
+    rsvpStatus: "Confirmed",
     appSubmissionTime: "2024-01-02T00:00:00.000Z",
     applicationResponses: { school: "NEU" },
   },
   // 4
   {
-    applicationStatus: "submitted",
-    decisionStatus: "admitted",
-    rsvpStatus: "not-attending",
+    applicationStatus: "Submitted",
+    decisionStatus: "Admitted",
+    rsvpStatus: "Not Attending",
     appSubmissionTime: "2024-01-02T00:00:00.000Z",
     applicationResponses: { school: "BU" },
   },
   // 5
   {
-    applicationStatus: "submitted",
-    decisionStatus: "waitlisted",
+    applicationStatus: "Submitted",
+    decisionStatus: "Waitlisted",
     appSubmissionTime: "2024-01-03T00:00:00.000Z",
     applicationResponses: { school: "BU" },
   },
   // 6
   {
-    applicationStatus: "submitted",
-    decisionStatus: "declined",
+    applicationStatus: "Submitted",
+    decisionStatus: "Declined",
     appSubmissionTime: "2024-01-03T00:00:00.000Z",
     applicationResponses: { school: "MIT" },
   },
   // 7
   {
-    applicationStatus: "submitted",
-    decisionStatus: "declined",
+    applicationStatus: "Submitted",
+    decisionStatus: "Declined",
     appSubmissionTime: "2024-01-04T00:00:00.000Z",
     applicationResponses: { school: "MIT" },
   },
   // 8
   {
-    applicationStatus: "submitted",
-    decisionStatus: "admitted",
-    rsvpStatus: "confirmed",
+    applicationStatus: "Submitted",
+    decisionStatus: "Admitted",
+    rsvpStatus: "Confirmed",
     appSubmissionTime: "2024-01-04T00:00:00.000Z",
     applicationResponses: { school: "NEU" },
   },
@@ -75,9 +77,9 @@ const APPLICANTS = [
   { applicationStatus: "in-progress" },
   // 10
   {
-    applicationStatus: "submitted",
-    decisionStatus: "admitted",
-    rsvpStatus: "unconfirmed",
+    applicationStatus: "Submitted",
+    decisionStatus: "Admitted",
+    rsvpStatus: "Unconfirmed",
     appSubmissionTime: "2024-01-05T00:00:00.000Z",
     applicationResponses: { school: "BU" },
   },
@@ -145,7 +147,7 @@ describe("getRsvpBreakdown", () => {
   it("groups rsvpStatus among admitted applicants", async () => {
     expect(await getRsvpBreakdown(db)).toEqual([
       { status: "confirmed", count: 3 },
-      { status: "not-attending", count: 1 },
+      { status: "not attending", count: 1 },
       { status: "unconfirmed", count: 1 },
     ]);
   });

--- a/apps/app-portal/src/lib/stats/aggregations.test.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.test.ts
@@ -1,0 +1,180 @@
+import { MongoClient } from "mongodb";
+import type { Db } from "mongodb";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+import {
+  getDecisionBreakdown,
+  getDemographics,
+  getRsvpBreakdown,
+  getStatusBreakdown,
+  getTimeline,
+  getTotals,
+} from "./aggregations";
+
+// NODE_ENV in jest defaults to "test", so resolveCollectionName() picks the
+// "_test" suffixed collection name.
+const COLLECTION_NAME = "applicant_data_test";
+
+const APPLICANTS = [
+  // 1: not-started, no decision/rsvp, no submission
+  { applicationStatus: "not-started" },
+  // 2
+  {
+    applicationStatus: "submitted",
+    decisionStatus: "admitted",
+    rsvpStatus: "confirmed",
+    appSubmissionTime: "2024-01-01T00:00:00.000Z",
+    applicationResponses: { school: "NEU" },
+  },
+  // 3
+  {
+    applicationStatus: "submitted",
+    decisionStatus: "admitted",
+    rsvpStatus: "confirmed",
+    appSubmissionTime: "2024-01-02T00:00:00.000Z",
+    applicationResponses: { school: "NEU" },
+  },
+  // 4
+  {
+    applicationStatus: "submitted",
+    decisionStatus: "admitted",
+    rsvpStatus: "not-attending",
+    appSubmissionTime: "2024-01-02T00:00:00.000Z",
+    applicationResponses: { school: "BU" },
+  },
+  // 5
+  {
+    applicationStatus: "submitted",
+    decisionStatus: "waitlisted",
+    appSubmissionTime: "2024-01-03T00:00:00.000Z",
+    applicationResponses: { school: "BU" },
+  },
+  // 6
+  {
+    applicationStatus: "submitted",
+    decisionStatus: "declined",
+    appSubmissionTime: "2024-01-03T00:00:00.000Z",
+    applicationResponses: { school: "MIT" },
+  },
+  // 7
+  {
+    applicationStatus: "submitted",
+    decisionStatus: "declined",
+    appSubmissionTime: "2024-01-04T00:00:00.000Z",
+    applicationResponses: { school: "MIT" },
+  },
+  // 8
+  {
+    applicationStatus: "submitted",
+    decisionStatus: "admitted",
+    rsvpStatus: "confirmed",
+    appSubmissionTime: "2024-01-04T00:00:00.000Z",
+    applicationResponses: { school: "NEU" },
+  },
+  // 9: in-progress, no decision/rsvp, no submission
+  { applicationStatus: "in-progress" },
+  // 10
+  {
+    applicationStatus: "submitted",
+    decisionStatus: "admitted",
+    rsvpStatus: "unconfirmed",
+    appSubmissionTime: "2024-01-05T00:00:00.000Z",
+    applicationResponses: { school: "BU" },
+  },
+];
+
+let mongod: MongoMemoryServer;
+let client: MongoClient;
+let db: Db;
+
+beforeAll(async () => {
+  mongod = await MongoMemoryServer.create();
+  client = await MongoClient.connect(mongod.getUri());
+  db = client.db("stats_test");
+  await db.collection(COLLECTION_NAME).insertMany(APPLICANTS);
+});
+
+afterAll(async () => {
+  await client.close();
+  await mongod.stop();
+});
+
+const byLabel = <T extends { label?: string; status?: string }>(
+  rows: T[],
+): T[] =>
+  [...rows].sort((a, b) =>
+    (a.label ?? a.status ?? "").localeCompare(b.label ?? b.status ?? ""),
+  );
+
+describe("getTotals", () => {
+  it("computes counts across all fields", async () => {
+    expect(await getTotals(db)).toEqual({
+      applicants: 10,
+      submitted: 8,
+      admitted: 5,
+      waitlisted: 1,
+      declined: 2,
+      rsvpYes: 3,
+      rsvpNo: 1,
+      rsvpUnconfirmed: 1,
+    });
+  });
+});
+
+describe("getStatusBreakdown", () => {
+  it("groups by applicationStatus", async () => {
+    expect(await getStatusBreakdown(db)).toEqual([
+      { status: "in-progress", count: 1 },
+      { status: "not-started", count: 1 },
+      { status: "submitted", count: 8 },
+    ]);
+  });
+});
+
+describe("getDecisionBreakdown", () => {
+  it("groups decisionStatus among submitted applicants", async () => {
+    expect(await getDecisionBreakdown(db)).toEqual([
+      { status: "admitted", count: 5 },
+      { status: "declined", count: 2 },
+      { status: "waitlisted", count: 1 },
+    ]);
+  });
+});
+
+describe("getRsvpBreakdown", () => {
+  it("groups rsvpStatus among admitted applicants", async () => {
+    expect(await getRsvpBreakdown(db)).toEqual([
+      { status: "confirmed", count: 3 },
+      { status: "not-attending", count: 1 },
+      { status: "unconfirmed", count: 1 },
+    ]);
+  });
+});
+
+describe("getTimeline", () => {
+  it("groups submissions by day", async () => {
+    expect(await getTimeline(db)).toEqual([
+      { date: "2024-01-01", count: 1 },
+      { date: "2024-01-02", count: 2 },
+      { date: "2024-01-03", count: 2 },
+      { date: "2024-01-04", count: 2 },
+      { date: "2024-01-05", count: 1 },
+    ]);
+  });
+});
+
+describe("getDemographics", () => {
+  it("groups the school dimension from applicationResponses", async () => {
+    const demographics = await getDemographics(db);
+    expect(byLabel(demographics.school)).toEqual([
+      { label: "BU", count: 3 },
+      { label: "MIT", count: 2 },
+      { label: "NEU", count: 3 },
+    ]);
+  });
+
+  it("returns no rows for dimensions with no data", async () => {
+    const demographics = await getDemographics(db);
+    expect(demographics.gender).toEqual([]);
+  });
+});

--- a/apps/app-portal/src/lib/stats/aggregations.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.ts
@@ -97,14 +97,13 @@ export async function getTotals(db: Db): Promise<StatsTotals> {
     rsvpUnconfirmed,
   ] = await Promise.all([
     col.countDocuments({}),
-    col.countDocuments(lowerEq("applicationStatus", "submitted")),
-    col.countDocuments(lowerEq("decisionStatus", "admitted")),
-    col.countDocuments(lowerEq("decisionStatus", "waitlisted")),
-    col.countDocuments(lowerEq("decisionStatus", "declined")),
-    col.countDocuments(lowerEq("rsvpStatus", "confirmed")),
-    col.countDocuments(lowerEq("rsvpStatus", "not-attending")),
-    col.countDocuments(lowerEq("rsvpStatus", "unconfirmed")),
-  ]);
+    col.countDocuments({ applicationStatus: "submitted" }),
+    col.countDocuments({ decisionStatus: "admitted" }),
+    col.countDocuments({ decisionStatus: "waitlisted" }),
+    col.countDocuments({ decisionStatus: "declined" }),
+    col.countDocuments({ rsvpStatus: "confirmed" }),
+    col.countDocuments({ rsvpStatus: "not-attending" }),
+    col.countDocuments({ rsvpStatus: "unconfirmed" }),
   return {
     applicants,
     submitted,

--- a/apps/app-portal/src/lib/stats/aggregations.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.ts
@@ -64,26 +64,6 @@ const lowerEq = (field: string, value: string): Document => ({
   $expr: { $eq: [{ $toLower: `$${field}` }, value] },
 });
 
-export const topLevelCountsPipeline: Document[] = [
-  {
-    $facet: {
-      totalApplications: [{ $count: "count" }],
-      submitted: [
-        { $match: lowerEq("applicationStatus", "submitted") },
-        { $count: "count" },
-      ],
-      admitted: [
-        { $match: lowerEq("decisionStatus", "admitted") },
-        { $count: "count" },
-      ],
-      confirmed: [
-        { $match: lowerEq("rsvpStatus", "confirmed") },
-        { $count: "count" },
-      ],
-    },
-  },
-];
-
 export async function getTotals(db: Db): Promise<StatsTotals> {
   const col = db.collection(APPLICANT_COLLECTION);
   const [
@@ -97,13 +77,14 @@ export async function getTotals(db: Db): Promise<StatsTotals> {
     rsvpUnconfirmed,
   ] = await Promise.all([
     col.countDocuments({}),
-    col.countDocuments({ applicationStatus: "submitted" }),
-    col.countDocuments({ decisionStatus: "admitted" }),
-    col.countDocuments({ decisionStatus: "waitlisted" }),
-    col.countDocuments({ decisionStatus: "declined" }),
-    col.countDocuments({ rsvpStatus: "confirmed" }),
-    col.countDocuments({ rsvpStatus: "not-attending" }),
-    col.countDocuments({ rsvpStatus: "unconfirmed" }),
+    col.countDocuments({ applicationStatus: "Submitted" }),
+    col.countDocuments({ decisionStatus: "Admitted" }),
+    col.countDocuments({ decisionStatus: "Waitlisted" }),
+    col.countDocuments({ decisionStatus: "Declined" }),
+    col.countDocuments({ rsvpStatus: "Confirmed" }),
+    col.countDocuments({ rsvpStatus: "Not Attending" }),
+    col.countDocuments({ rsvpStatus: "Unconfirmed" }),
+  ]);
   return {
     applicants,
     submitted,
@@ -126,7 +107,7 @@ export async function getStatusBreakdown(db: Db): Promise<BreakdownEntry[]> {
 export async function getDecisionBreakdown(db: Db): Promise<BreakdownEntry[]> {
   const col = db.collection(APPLICANT_COLLECTION);
   const pipeline = [
-    { $match: { applicationStatus: "submitted" } },
+    { $match: { applicationStatus: "Submitted" } },
     ...statusBreakdownPipeline("decisionStatus"),
   ];
   return col.aggregate<BreakdownEntry>(pipeline).toArray();

--- a/apps/app-portal/src/lib/stats/aggregations.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.ts
@@ -94,14 +94,16 @@ export async function getTotals(db: Db): Promise<StatsTotals> {
     declined,
     rsvpYes,
     rsvpNo,
+    rsvpUnconfirmed,
   ] = await Promise.all([
     col.countDocuments({}),
-    col.countDocuments({ applicationStatus: "submitted" }),
-    col.countDocuments({ decisionStatus: "admitted" }),
-    col.countDocuments({ decisionStatus: "waitlisted" }),
-    col.countDocuments({ decisionStatus: "declined" }),
-    col.countDocuments({ rsvpStatus: "confirmed" }),
-    col.countDocuments({ rsvpStatus: "not-attending" }),
+    col.countDocuments(lowerEq("applicationStatus", "submitted")),
+    col.countDocuments(lowerEq("decisionStatus", "admitted")),
+    col.countDocuments(lowerEq("decisionStatus", "waitlisted")),
+    col.countDocuments(lowerEq("decisionStatus", "declined")),
+    col.countDocuments(lowerEq("rsvpStatus", "confirmed")),
+    col.countDocuments(lowerEq("rsvpStatus", "not-attending")),
+    col.countDocuments(lowerEq("rsvpStatus", "unconfirmed")),
   ]);
   return {
     applicants,
@@ -111,6 +113,7 @@ export async function getTotals(db: Db): Promise<StatsTotals> {
     declined,
     rsvpYes,
     rsvpNo,
+    rsvpUnconfirmed,
   };
 }
 

--- a/apps/app-portal/src/lib/stats/aggregations.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.ts
@@ -126,7 +126,7 @@ export async function getStatusBreakdown(db: Db): Promise<BreakdownEntry[]> {
 export async function getDecisionBreakdown(db: Db): Promise<BreakdownEntry[]> {
   const col = db.collection(APPLICANT_COLLECTION);
   const pipeline = [
-    { $match: lowerEq("applicationStatus", "submitted") },
+    { $match: { applicationStatus: "submitted" } },
     ...statusBreakdownPipeline("decisionStatus"),
   ];
   return col.aggregate<BreakdownEntry>(pipeline).toArray();

--- a/apps/app-portal/src/lib/stats/aggregations.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.ts
@@ -86,17 +86,32 @@ export const topLevelCountsPipeline: Document[] = [
 
 export async function getTotals(db: Db): Promise<StatsTotals> {
   const col = db.collection(APPLICANT_COLLECTION);
-  const [applicants, submitted, admitted, waitlisted, declined, rsvpYes, rsvpNo] =
-    await Promise.all([
-      col.countDocuments({}),
-      col.countDocuments({ applicationStatus: "submitted" }),
-      col.countDocuments({ decisionStatus: "admitted" }),
-      col.countDocuments({ decisionStatus: "waitlisted" }),
-      col.countDocuments({ decisionStatus: "declined" }),
-      col.countDocuments({ rsvpStatus: "confirmed" }),
-      col.countDocuments({ rsvpStatus: "not-attending" }),
-    ]);
-  return { applicants, submitted, admitted, waitlisted, declined, rsvpYes, rsvpNo };
+  const [
+    applicants,
+    submitted,
+    admitted,
+    waitlisted,
+    declined,
+    rsvpYes,
+    rsvpNo,
+  ] = await Promise.all([
+    col.countDocuments({}),
+    col.countDocuments({ applicationStatus: "submitted" }),
+    col.countDocuments({ decisionStatus: "admitted" }),
+    col.countDocuments({ decisionStatus: "waitlisted" }),
+    col.countDocuments({ decisionStatus: "declined" }),
+    col.countDocuments({ rsvpStatus: "confirmed" }),
+    col.countDocuments({ rsvpStatus: "not-attending" }),
+  ]);
+  return {
+    applicants,
+    submitted,
+    admitted,
+    waitlisted,
+    declined,
+    rsvpYes,
+    rsvpNo,
+  };
 }
 
 export async function getStatusBreakdown(db: Db): Promise<BreakdownEntry[]> {
@@ -129,9 +144,10 @@ export async function getDemographics(db: Db): Promise<DemographicsBreakdown> {
   const entries = await Promise.all(
     DEMOGRAPHICS_DIMENSIONS.map(async (dimension) => {
       const rows = await col
-        .aggregate<{ label: string; count: number }>(
-          demographicsBreakdownPipeline(dimension),
-        )
+        .aggregate<{
+          label: string;
+          count: number;
+        }>(demographicsBreakdownPipeline(dimension))
         .toArray();
       return [dimension, rows] as const;
     }),
@@ -139,13 +155,17 @@ export async function getDemographics(db: Db): Promise<DemographicsBreakdown> {
   return Object.fromEntries(entries) as DemographicsBreakdown;
 }
 
-export async function getTimeline(db: Db, days: number): Promise<TimelinePoint[]> {
+export async function getTimeline(
+  db: Db,
+  days?: number,
+): Promise<TimelinePoint[]> {
   const col = db.collection(APPLICANT_COLLECTION);
-  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-  const pipeline = [
-    { $match: { appSubmissionTime: { $exists: true, $ne: null, $gte: since.toISOString() } } },
-    ...submissionTimelinePipeline.slice(1),
-  ];
+  const match: Document = { appSubmissionTime: { $exists: true, $ne: null } };
+  if (days !== undefined) {
+    const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    match.appSubmissionTime.$gte = since.toISOString();
+  }
+  const pipeline = [{ $match: match }, ...submissionTimelinePipeline.slice(1)];
   const rows = await col
     .aggregate<{ date: string; submissions: number }>(pipeline)
     .toArray();

--- a/apps/app-portal/src/lib/stats/aggregations.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.ts
@@ -165,7 +165,7 @@ export async function getTimeline(
   const match: Document = { appSubmissionTime: { $exists: true, $ne: null } };
   if (days !== undefined) {
     const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
-    match.appSubmissionTime.$gte = since.toISOString();
+    match.appSubmissionTime.$gte = since;
   }
   const pipeline = [{ $match: match }, ...submissionTimelinePipeline.slice(1)];
   const rows = await col

--- a/apps/app-portal/src/lib/stats/aggregations.ts
+++ b/apps/app-portal/src/lib/stats/aggregations.ts
@@ -1,8 +1,19 @@
-import type { Document } from "mongodb";
+import type { Db, Document } from "mongodb";
 
-import type { DemographicsDimension } from "./types";
+import { resolveCollectionName } from "@/lib/db";
+
+import {
+  DEMOGRAPHICS_DIMENSIONS,
+  type BreakdownEntry,
+  type DemographicsBreakdown,
+  type StatsTotals,
+  type TimelinePoint,
+  type DemographicsDimension,
+} from "./types";
 
 type StatusField = "applicationStatus" | "decisionStatus" | "rsvpStatus";
+
+const APPLICANT_COLLECTION = resolveCollectionName("applicant_data");
 
 export function statusBreakdownPipeline(field: StatusField): Document[] {
   return [
@@ -72,3 +83,71 @@ export const topLevelCountsPipeline: Document[] = [
     },
   },
 ];
+
+export async function getTotals(db: Db): Promise<StatsTotals> {
+  const col = db.collection(APPLICANT_COLLECTION);
+  const [applicants, submitted, admitted, waitlisted, declined, rsvpYes, rsvpNo] =
+    await Promise.all([
+      col.countDocuments({}),
+      col.countDocuments({ applicationStatus: "submitted" }),
+      col.countDocuments({ decisionStatus: "admitted" }),
+      col.countDocuments({ decisionStatus: "waitlisted" }),
+      col.countDocuments({ decisionStatus: "declined" }),
+      col.countDocuments({ rsvpStatus: "confirmed" }),
+      col.countDocuments({ rsvpStatus: "not-attending" }),
+    ]);
+  return { applicants, submitted, admitted, waitlisted, declined, rsvpYes, rsvpNo };
+}
+
+export async function getStatusBreakdown(db: Db): Promise<BreakdownEntry[]> {
+  const col = db.collection(APPLICANT_COLLECTION);
+  return col
+    .aggregate<BreakdownEntry>(statusBreakdownPipeline("applicationStatus"))
+    .toArray();
+}
+
+export async function getDecisionBreakdown(db: Db): Promise<BreakdownEntry[]> {
+  const col = db.collection(APPLICANT_COLLECTION);
+  const pipeline = [
+    { $match: lowerEq("applicationStatus", "submitted") },
+    ...statusBreakdownPipeline("decisionStatus"),
+  ];
+  return col.aggregate<BreakdownEntry>(pipeline).toArray();
+}
+
+export async function getRsvpBreakdown(db: Db): Promise<BreakdownEntry[]> {
+  const col = db.collection(APPLICANT_COLLECTION);
+  const pipeline = [
+    { $match: lowerEq("decisionStatus", "admitted") },
+    ...statusBreakdownPipeline("rsvpStatus"),
+  ];
+  return col.aggregate<BreakdownEntry>(pipeline).toArray();
+}
+
+export async function getDemographics(db: Db): Promise<DemographicsBreakdown> {
+  const col = db.collection(APPLICANT_COLLECTION);
+  const entries = await Promise.all(
+    DEMOGRAPHICS_DIMENSIONS.map(async (dimension) => {
+      const rows = await col
+        .aggregate<{ label: string; count: number }>(
+          demographicsBreakdownPipeline(dimension),
+        )
+        .toArray();
+      return [dimension, rows] as const;
+    }),
+  );
+  return Object.fromEntries(entries) as DemographicsBreakdown;
+}
+
+export async function getTimeline(db: Db, days: number): Promise<TimelinePoint[]> {
+  const col = db.collection(APPLICANT_COLLECTION);
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  const pipeline = [
+    { $match: { appSubmissionTime: { $exists: true, $ne: null, $gte: since.toISOString() } } },
+    ...submissionTimelinePipeline.slice(1),
+  ];
+  const rows = await col
+    .aggregate<{ date: string; submissions: number }>(pipeline)
+    .toArray();
+  return rows.map(({ date, submissions }) => ({ date, count: submissions }));
+}

--- a/apps/app-portal/src/lib/stats/service.ts
+++ b/apps/app-portal/src/lib/stats/service.ts
@@ -10,7 +10,17 @@ import {
 } from "./aggregations";
 import type { StatsPayload } from "./types";
 
+const CACHE_TTL_MS = 60_000;
+
+// In-memory cache, per server process only. Fine at this scale (single instance,
+// admin-only traffic); won't stay in sync across multiple instances/replicas.
+let cache: { result: StatsPayload; timestamp: number } | null = null;
+
 export async function getStats(): Promise<StatsPayload> {
+  if (cache && Date.now() - cache.timestamp < CACHE_TTL_MS) {
+    return cache.result;
+  }
+
   const db = await getDb();
 
   const [
@@ -56,7 +66,7 @@ export async function getStats(): Promise<StatsPayload> {
     },
   ];
 
-  return {
+  const result: StatsPayload = {
     metrics,
     totals,
     statusBreakdown,
@@ -66,4 +76,7 @@ export async function getStats(): Promise<StatsPayload> {
     timeline,
     generatedAt: new Date().toISOString(),
   };
+
+  cache = { result, timestamp: Date.now() };
+  return result;
 }

--- a/apps/app-portal/src/lib/stats/service.ts
+++ b/apps/app-portal/src/lib/stats/service.ts
@@ -1,115 +1,69 @@
+import { getDb } from "@/lib/db";
+
+import {
+  getDecisionBreakdown,
+  getDemographics,
+  getRsvpBreakdown,
+  getStatusBreakdown,
+  getTimeline,
+  getTotals,
+} from "./aggregations";
 import type { StatsPayload } from "./types";
 
-// mock shape
 export async function getStats(): Promise<StatsPayload> {
+  const db = await getDb();
+
+  const [
+    totals,
+    statusBreakdown,
+    decisionBreakdown,
+    rsvpBreakdown,
+    demographics,
+    timeline,
+  ] = await Promise.all([
+    getTotals(db),
+    getStatusBreakdown(db),
+    getDecisionBreakdown(db),
+    getRsvpBreakdown(db),
+    getDemographics(db),
+    getTimeline(db),
+  ]);
+
+  const metrics = [
+    {
+      label: "Total Applications",
+      value: totals.applicants,
+      delta: 0,
+      description: "Everyone who has started their application.",
+    },
+    {
+      label: "Submitted",
+      value: totals.submitted,
+      delta: 0,
+      description: "Applications fully submitted and ready for review.",
+    },
+    {
+      label: "Admitted",
+      value: totals.admitted,
+      delta: 0,
+      description: "Applicants who have received an admit decision.",
+    },
+    {
+      label: "RSVP'd",
+      value: totals.rsvpYes,
+      delta: 0,
+      description: "Admitted applicants who have confirmed they'll attend.",
+    },
+  ];
+
   return {
-    metrics: [
-      {
-        label: "Total Applications",
-        value: 412,
-        delta: 38,
-        description: "Everyone who has started their application.",
-      },
-      {
-        label: "Submitted",
-        value: 287,
-        delta: 24,
-        description: "Applications fully submitted and ready for review.",
-      },
-      {
-        label: "Admitted",
-        value: 142,
-        delta: -12,
-        description: "Applicants who have received an admit decision.",
-      },
-      {
-        label: "RSVP'd",
-        value: null,
-        delta: 8,
-        description: "Admitted applicants who have confirmed they'll attend.",
-      },
-    ],
-    totals: {
-      applicants: 412,
-      submitted: 287,
-      admitted: 142,
-      waitlisted: 50,
-      declined: 75,
-      rsvpYes: 96,
-      rsvpNo: 16,
-    },
-    statusBreakdown: [
-      { status: "submitted", count: 287 },
-      { status: "under-review", count: 48 },
-      { status: "incomplete", count: 65 },
-      { status: "withdrawn", count: 22 },
-      { status: "not-started", count: 60 },
-      { status: "deferred", count: 9 },
-      { status: "expired", count: 14 },
-    ],
-    decisionBreakdown: [
-      { status: "pending", count: 145 },
-      { status: "admitted", count: 142 },
-      { status: "waitlisted", count: 50 },
-      { status: "declined", count: 75 },
-    ],
-    rsvpBreakdown: [
-      { status: "unconfirmed", count: 30 },
-      { status: "confirmed", count: 96 },
-      { status: "not-attending", count: 16 },
-    ],
-    demographics: {
-      school: [
-        { label: "Northeastern University", count: 134 },
-        { label: "MIT", count: 58 },
-        { label: "Boston University", count: 49 },
-        { label: "Tufts University", count: 31 },
-        { label: "Harvard University", count: 23 },
-      ],
-      yearOfEducation: [
-        { label: "1st year", count: 78 },
-        { label: "2nd year", count: 92 },
-        { label: "3rd year", count: 67 },
-        { label: "4th year", count: 50 },
-      ],
-      gender: [
-        { label: "Male", count: 168 },
-        { label: "Female", count: 102 },
-        { label: "Non-binary", count: 12 },
-      ],
-      races: [
-        { label: "Asian", count: 140 },
-        { label: "White", count: 95 },
-        { label: "Hispanic or Latino", count: 28 },
-        { label: "Black or African American", count: 18 },
-      ],
-      shirtSize: [
-        { label: "S", count: 38 },
-        { label: "M", count: 112 },
-        { label: "L", count: 95 },
-        { label: "XL", count: 42 },
-      ],
-      hackathonsAttended: [
-        { label: "0", count: 132 },
-        { label: "1-2", count: 78 },
-        { label: "3-5", count: 40 },
-        { label: "6+", count: 37 },
-      ],
-      csClassesTaken: [
-        { label: "0", count: 60 },
-        { label: "1-2", count: 150 },
-        { label: "3+", count: 77 },
-      ],
-    },
-    timeline: [
-      { date: "2026-04-01", count: 12 },
-      { date: "2026-04-02", count: 28 },
-      { date: "2026-04-03", count: 41 },
-      { date: "2026-04-04", count: 36 },
-      { date: "2026-04-05", count: 55 },
-      { date: "2026-04-06", count: 62 },
-      { date: "2026-04-07", count: 53 },
-    ],
+    metrics,
+    totals,
+    statusBreakdown,
+    decisionBreakdown,
+    rsvpBreakdown,
+    demographics,
+    timeline,
     generatedAt: new Date().toISOString(),
   };
 }

--- a/apps/app-portal/src/lib/stats/service.ts
+++ b/apps/app-portal/src/lib/stats/service.ts
@@ -29,28 +29,35 @@ export async function getStats(): Promise<StatsPayload> {
         description: "Admitted applicants who have confirmed they'll attend.",
       },
     ],
-    statusBreakdown: {
-      application: [
-        { status: "submitted", count: 287 },
-        { status: "under-review", count: 48 },
-        { status: "incomplete", count: 65 },
-        { status: "withdrawn", count: 22 },
-        { status: "not-started", count: 60 },
-        { status: "deferred", count: 9 },
-        { status: "expired", count: 14 },
-      ],
-      decision: [
-        { status: "pending", count: 145 },
-        { status: "admitted", count: 142 },
-        { status: "waitlisted", count: 50 },
-        { status: "declined", count: 75 },
-      ],
-      rsvp: [
-        { status: "unconfirmed", count: 30 },
-        { status: "confirmed", count: 96 },
-        { status: "not-attending", count: 16 },
-      ],
+    totals: {
+      applicants: 412,
+      submitted: 287,
+      admitted: 142,
+      waitlisted: 50,
+      declined: 75,
+      rsvpYes: 96,
+      rsvpNo: 16,
     },
+    statusBreakdown: [
+      { status: "submitted", count: 287 },
+      { status: "under-review", count: 48 },
+      { status: "incomplete", count: 65 },
+      { status: "withdrawn", count: 22 },
+      { status: "not-started", count: 60 },
+      { status: "deferred", count: 9 },
+      { status: "expired", count: 14 },
+    ],
+    decisionBreakdown: [
+      { status: "pending", count: 145 },
+      { status: "admitted", count: 142 },
+      { status: "waitlisted", count: 50 },
+      { status: "declined", count: 75 },
+    ],
+    rsvpBreakdown: [
+      { status: "unconfirmed", count: 30 },
+      { status: "confirmed", count: 96 },
+      { status: "not-attending", count: 16 },
+    ],
     demographics: {
       school: [
         { label: "Northeastern University", count: 134 },
@@ -99,13 +106,14 @@ export async function getStats(): Promise<StatsPayload> {
       ],
     },
     timeline: [
-      { date: "2026-04-01", submissions: 12 },
-      { date: "2026-04-02", submissions: 28 },
-      { date: "2026-04-03", submissions: 41 },
-      { date: "2026-04-04", submissions: 36 },
-      { date: "2026-04-05", submissions: 55 },
-      { date: "2026-04-06", submissions: 62 },
-      { date: "2026-04-07", submissions: 53 },
+      { date: "2026-04-01", count: 12 },
+      { date: "2026-04-02", count: 28 },
+      { date: "2026-04-03", count: 41 },
+      { date: "2026-04-04", count: 36 },
+      { date: "2026-04-05", count: 55 },
+      { date: "2026-04-06", count: 62 },
+      { date: "2026-04-07", count: 53 },
     ],
+    generatedAt: new Date().toISOString(),
   };
 }

--- a/apps/app-portal/src/lib/stats/service.ts
+++ b/apps/app-portal/src/lib/stats/service.ts
@@ -66,26 +66,16 @@ export async function getStats(): Promise<StatsPayload> {
         { label: "Tufts University", count: 31 },
         { label: "Harvard University", count: 23 },
       ],
-      education: [
-        { label: "Undergraduate", count: 245 },
-        { label: "Graduate", count: 42 },
-      ],
-      year_of_study: [
+      yearOfEducation: [
         { label: "1st year", count: 78 },
         { label: "2nd year", count: 92 },
         { label: "3rd year", count: 67 },
         { label: "4th year", count: 50 },
       ],
-      majors: [
-        { label: "Computer Science", count: 187 },
-        { label: "Data Science", count: 42 },
-        { label: "Electrical Engineering", count: 28 },
-      ],
       gender: [
         { label: "Male", count: 168 },
         { label: "Female", count: 102 },
         { label: "Non-binary", count: 12 },
-        { label: "Prefer not to say", count: 5 },
       ],
       races: [
         { label: "Asian", count: 140 },
@@ -93,16 +83,22 @@ export async function getStats(): Promise<StatsPayload> {
         { label: "Hispanic or Latino", count: 28 },
         { label: "Black or African American", count: 18 },
       ],
-      shirt_size: [
+      shirtSize: [
         { label: "S", count: 38 },
         { label: "M", count: 112 },
         { label: "L", count: 95 },
         { label: "XL", count: 42 },
       ],
-      hackathon_experience: [
+      hackathonsAttended: [
         { label: "0", count: 132 },
-        { label: "1-3", count: 118 },
-        { label: "4+", count: 37 },
+        { label: "1-2", count: 78 },
+        { label: "3-5", count: 40 },
+        { label: "6+", count: 37 },
+      ],
+      csClassesTaken: [
+        { label: "0", count: 60 },
+        { label: "1-2", count: 150 },
+        { label: "3+", count: 77 },
       ],
     },
     timeline: [

--- a/apps/app-portal/src/lib/stats/types.ts
+++ b/apps/app-portal/src/lib/stats/types.ts
@@ -34,13 +34,12 @@ export interface BreakdownEntry {
 
 export const DEMOGRAPHICS_DIMENSIONS = [
   "school",
-  "education",
-  "year_of_study",
-  "majors",
+  "yearOfEducation",
   "gender",
   "races",
-  "shirt_size",
-  "hackathon_experience",
+  "shirtSize",
+  "hackathonsAttended",
+  "csClassesTaken",
 ] as const;
 
 export type DemographicsDimension = (typeof DEMOGRAPHICS_DIMENSIONS)[number];

--- a/apps/app-portal/src/lib/stats/types.ts
+++ b/apps/app-portal/src/lib/stats/types.ts
@@ -25,6 +25,7 @@ export interface StatsTotals {
   declined: number;
   rsvpYes: number;
   rsvpNo: number;
+  rsvpUnconfirmed: number;
 }
 
 export interface BreakdownEntry {

--- a/apps/app-portal/src/lib/stats/types.ts
+++ b/apps/app-portal/src/lib/stats/types.ts
@@ -1,8 +1,12 @@
 export interface StatsPayload {
   metrics: StatMetric[];
-  statusBreakdown: StatusBreakdown;
+  totals: StatsTotals;
+  statusBreakdown: BreakdownEntry[];
+  decisionBreakdown: BreakdownEntry[];
+  rsvpBreakdown: BreakdownEntry[];
   demographics: DemographicsBreakdown;
   timeline: TimelinePoint[];
+  generatedAt: string;
 }
 
 // single metric
@@ -13,12 +17,20 @@ export interface StatMetric {
   description?: string; // shown in StatCard hover tooltip
 }
 
-export type StatusKind = "application" | "decision" | "rsvp";
+export interface StatsTotals {
+  applicants: number;
+  submitted: number;
+  admitted: number;
+  waitlisted: number;
+  declined: number;
+  rsvpYes: number;
+  rsvpNo: number;
+}
 
-export type StatusBreakdown = Record<
-  StatusKind,
-  { status: string; count: number }[]
->;
+export interface BreakdownEntry {
+  status: string;
+  count: number;
+}
 
 export const DEMOGRAPHICS_DIMENSIONS = [
   "school",
@@ -40,5 +52,5 @@ export type DemographicsBreakdown = Record<
 
 export interface TimelinePoint {
   date: string;
-  submissions: number;
+  count: number;
 }

--- a/apps/app-portal/src/lib/stats/types.ts
+++ b/apps/app-portal/src/lib/stats/types.ts
@@ -35,6 +35,7 @@ export interface BreakdownEntry {
 export const DEMOGRAPHICS_DIMENSIONS = [
   "school",
   "yearOfEducation",
+  "majors",
   "gender",
   "races",
   "shirtSize",


### PR DESCRIPTION
# Add /admin/stats dashboard: get live Mongo data, service, API, jest unit tests

## 🎫 Issue #487 

### ▶ Changelist:

For http://localhost:3000/admin/stats 
- Split StatusBreakdownChart into application, decision, and RSVP breakdowns as three separate cards
- Added getTotals, getStatusBreakdown, getDecisionBreakdown, getRsvpBreakdown, getDemographics, getTimeline aggregation functions against applicant_data
- Reworked types.ts to match applicant_data
- Cache + API route for stats payload, dynamic loading for /stats route
- Added jest config + unit tests per aggregation 
- Pre-commit hook now fails fast if next dev is running (conflicts with yarn build)


### 🎥 Screenshots & Screencasts:

Stats Page with Mongo Prod applicant data! 
<img width="1348" height="850" alt="image" src="https://github.com/user-attachments/assets/219fd716-76ab-4b18-8140-c739817780b3" />

<img width="1161" height="772" alt="image" src="https://github.com/user-attachments/assets/364f56c7-b93e-45b3-9df8-480c080bc727" />


### 📝 Notes + 🚧 TODO:

- Demographics dimension selector still TODO (see StatsDashboard)
- Fix chart x-xis overflow: 
<img width="504" height="334" alt="image" src="https://github.com/user-attachments/assets/34cbc828-d274-4e60-b3b7-58c548a9d231" />


- Brainstorm better way to represent all the diff majors for x-axis:
<img width="514" height="333" alt="image" src="https://github.com/user-attachments/assets/e06c7009-7532-40de-a968-96eaba7579c1" />


Note: to access this page, user must log into platform with ...@hackbeanpot.com credentials!

### 🧪 Testing:

- yarn test — unit tests (mongodb-memory-server) covering:
getTotals: counts across all status fields correct
getStatusBreakdown: groups by applicationStatus
getDecisionBreakdown: groups decisionStatus scoped to submitted applicants only
getRsvpBreakdown: groups rsvpStatus scoped to admitted applicants only
getTimeline: groups submissions by day
getDemographics: groups school dimension from applicationResponses; returns empty rows for dimensions with no data
- double checked with Mongo values 
- curl tested payload, counts, timeline
- smoke tested [page](http://localhost:3000/admin/stats) 
